### PR TITLE
Generate license attribution files during image build

### DIFF
--- a/build_artifacts/v0/v0.2/v0.2.2/Dockerfile
+++ b/build_artifacts/v0/v0.2/v0.2.2/Dockerfile
@@ -19,7 +19,7 @@ RUN usermod "--login=${NB_USER}" "--home=/home/${NB_USER}" --move-home "-u ${NB_
 ENV MAMBA_USER=$NB_USER
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends sudo gettext-base wget curl awscli && \
+    apt-get install -y --no-install-recommends sudo gettext-base wget curl awscli unzip && \
     # We just install tzdata below but leave default time zone as UTC. This helps packages like Pandas to function correctly.
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \
     chmod g+w /etc/passwd && \
@@ -47,5 +47,17 @@ RUN micromamba install -y --name base --file /tmp/$ENV_IN_FILENAME && \
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
 RUN sudo ln -s $(which python3) /usr/bin/python
 
+USER root
+RUN HOME_DIR="/home/${NB_USER}/licenses" \
+    && mkdir -p ${HOME_DIR} \
+    && curl -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip \
+    && unzip ${HOME_DIR}/oss_compliance.zip -d ${HOME_DIR}/ \
+    && cp ${HOME_DIR}/oss_compliance/test/testOSSCompliance /usr/local/bin/testOSSCompliance \
+    && chmod +x /usr/local/bin/testOSSCompliance \
+    && chmod +x ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh \
+    && ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh ${HOME_DIR} python \
+    && rm -rf ${HOME_DIR}/oss_compliance*
+
+USER $MAMBA_USER
 WORKDIR "/home/${NB_USER}"
 ENV SHELL=/bin/bash


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Adds a step in the dockerfile to generate license attribution files into a new directory called "licenses" in the sagemaker-user home path. The snippet of code is taken from DLC image implementation ([ref](https://github.com/aws/deep-learning-containers/blob/master/pytorch/training/docker/2.0/py3/Dockerfile.cpu#L207-L215)). It consists of downloading, unzipping, and executing a python utility from s3.


Open questions for reviewers
* Is `/home/sagemaker-user/licenses` the appropriate location to output the license files? Keep in mind the license information is meant to be visible to end-users and thus directory permissions should be considered.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
