### PR TITLE
Add conda bin paths to env PATH

### DIFF
--- a/build_artifacts/v0/v0.3/v0.3.0/Dockerfile
+++ b/build_artifacts/v0/v0.3/v0.3.0/Dockerfile
@@ -59,5 +59,6 @@ RUN HOME_DIR="/home/${NB_USER}/licenses" \
     && rm -rf ${HOME_DIR}/oss_compliance*
 
 USER $MAMBA_USER
+ENV PATH="/opt/conda/bin:/opt/conda/condabin:$PATH"
 WORKDIR "/home/${NB_USER}"
 ENV SHELL=/bin/bash


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Some use cases may start a container of a sagemaker-distribution image with a docker `--entrypoint` override which bypasses micromamba's automatic activation. In the case of Jupyter remote kernels, activation of the environment itself is handled by ipykernel, but forgoing the automatic activation also crucially skips the step where conda bin paths are added to the environment PATH. This change explicitly adds them to the image's PATH.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
