### PR TITLE
fix: Updated tests to use --freeze-installed flag during micromamba installations

### DIFF
--- a/test/test_artifacts/boto3.test.Dockerfile
+++ b/test/test_artifacts/boto3.test.Dockerfile
@@ -7,7 +7,7 @@ RUN sudo apt-get update && sudo apt-get install -y git && \
     :
 
 # For Running boto3 tests, we need pytest
-RUN micromamba install -y conda-forge::pytest
+RUN micromamba install -y --freeze-installed conda-forge::pytest
 
 
 WORKDIR "boto3"

--- a/test/test_artifacts/keras.test.Dockerfile
+++ b/test/test_artifacts/keras.test.Dockerfile
@@ -8,7 +8,7 @@ RUN sudo apt-get update && sudo apt-get install -y git && \
     :
 
 # Some of the keras guides requires pydot and graphviz to be installed
-RUN micromamba install -y conda-forge::pydot conda-forge::graphviz nvidia::cuda-nvcc
+RUN micromamba install -y --freeze-installed conda-forge::pydot conda-forge::graphviz nvidia::cuda-nvcc
 ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/opt/conda
 
 WORKDIR "keras-io/guides"

--- a/test/test_artifacts/numpy.test.Dockerfile
+++ b/test/test_artifacts/numpy.test.Dockerfile
@@ -4,7 +4,7 @@ FROM $COSMOS_IMAGE
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
 
 # Inorder to test numpy, we need pytest and hypothesis to be installed.
-RUN micromamba install -y conda-forge::pytest conda-forge::hypothesis
+RUN micromamba install -y --freeze-installed conda-forge::pytest conda-forge::hypothesis
 # Some unit tests in numpy requires gcc to be installed.
 RUN sudo apt-get update && sudo apt-get install -y gcc
 # Check https://numpy.org/doc/stable/reference/testing.html

--- a/test/test_artifacts/pandas.test.Dockerfile
+++ b/test/test_artifacts/pandas.test.Dockerfile
@@ -2,7 +2,7 @@ ARG COSMOS_IMAGE
 FROM $COSMOS_IMAGE
 
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
-RUN micromamba install -y -c conda-forge pytest hypothesis
+RUN micromamba install -y --freeze-installed -c conda-forge pytest hypothesis
 
 COPY --chown=$MAMBA_USER:$MAMBA_USER run_pandas_tests.py .
 CMD ["python", "run_pandas_tests.py"]

--- a/test/test_artifacts/scipy.test.Dockerfile
+++ b/test/test_artifacts/scipy.test.Dockerfile
@@ -4,7 +4,7 @@ FROM $COSMOS_IMAGE
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
 
 # Inorder to test scipy, we need pytest and hypothesis to be installed.
-RUN micromamba install -y conda-forge::pytest conda-forge::hypothesis conda-forge::scipy-tests
+RUN micromamba install -y --freeze-installed conda-forge::pytest conda-forge::hypothesis conda-forge::scipy-tests
 # Check https://github.com/numpy/numpy/blob/main/doc/TESTS.rst
 # Note: Testing guidelines are same for numpy and scipy.
 # scipy.test() returns True if tests succeed else False.

--- a/test/test_artifacts/tensorflow.examples.Dockerfile
+++ b/test/test_artifacts/tensorflow.examples.Dockerfile
@@ -11,6 +11,6 @@ WORKDIR "docs/site/en/guide"
 COPY --chown=$MAMBA_USER:$MAMBA_USER ./tensorflow/ ./
 RUN chmod +x run_tensorflow_example_notebooks.sh
 
-RUN micromamba install -y -c conda-forge papermill
+RUN micromamba install -y --freeze-installed -c conda-forge papermill
 
 CMD ["./run_tensorflow_example_notebooks.sh"]


### PR DESCRIPTION

*Issue #, if available:* N/A

*Description of changes:* Updated tests to use --freeze-installed flag during micromamba installations

*Testing:* Ran the tests to verify whether the tests are passing successfully with freeze-installed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
