### PR TITLE
fix: Move Dockerfile to a new template directory and modify the version generator script to copy from that file

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -90,9 +90,10 @@ def _create_new_version_artifacts(args):
 
 
 def _copy_static_files(base_version_dir, new_version_dir):
-    for name in ['gpu.arg_based_env.in', 'Dockerfile']:
-        for f in glob.glob(f'{base_version_dir}/{name}'):
-            shutil.copy2(f, new_version_dir)
+    for f in glob.glob(f'{base_version_dir}/gpu.arg_based_env.in'):
+        shutil.copy2(f, new_version_dir)
+    for f in glob.glob(os.path.relpath(f'template/Dockerfile')):
+        shutil.copy2(f, new_version_dir)
 
 
 def _create_new_version_conda_specs(base_version_dir, new_version_dir, runtime_version_upgrade_type,

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -1,0 +1,64 @@
+ARG TAG_FOR_BASE_MICROMAMBA_IMAGE
+FROM mambaorg/micromamba:$TAG_FOR_BASE_MICROMAMBA_IMAGE
+
+ARG CUDA_MAJOR_MINOR_VERSION=''
+ARG ENV_IN_FILENAME
+ARG ARG_BASED_ENV_IN_FILENAME
+
+ARG NB_USER="sagemaker-user"
+ARG NB_UID=1000
+ARG NB_GID=100
+
+USER root
+RUN usermod "--login=${NB_USER}" "--home=/home/${NB_USER}" --move-home "-u ${NB_UID}" "${MAMBA_USER}" && \
+    groupmod "--new-name=${NB_USER}" --non-unique "-g ${NB_GID}" "${MAMBA_USER}" && \
+    # Update the expected value of MAMBA_USER for the
+    # _entrypoint.sh consistency check.
+    echo "${NB_USER}" > "/etc/arg_mamba_user" && \
+    :
+ENV MAMBA_USER=$NB_USER
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends sudo gettext-base wget curl awscli unzip && \
+    # We just install tzdata below but leave default time zone as UTC. This helps packages like Pandas to function correctly.
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \
+    chmod g+w /etc/passwd && \
+    echo "ALL    ALL=(ALL)    NOPASSWD:    ALL" >> /etc/sudoers && \
+    # Note that we do NOT run `rm -rf /var/lib/apt/lists/*` here. If we did, anyone building on top of our images will
+    # not be able to run any `apt-get install` commands and that would hamper customizability of the images.
+    :
+RUN echo "source /usr/local/bin/_activate_current_env.sh" | tee --append /etc/profile
+
+USER $MAMBA_USER
+COPY --chown=$MAMBA_USER:$MAMBA_USER *.in /tmp/
+
+# Make sure that $ENV_IN_FILENAME has a newline at the end before the `tee` command runs. Otherwise, nasty things
+# will happen.
+RUN if [[ -z $ARG_BASED_ENV_IN_FILENAME ]] ; \
+    then echo 'No ARG_BASED_ENV_IN_FILENAME passed' ; \
+    else envsubst < /tmp/$ARG_BASED_ENV_IN_FILENAME | tee --append /tmp/$ENV_IN_FILENAME ; \
+    fi
+
+ARG CONDA_OVERRIDE_CUDA=$CUDA_MAJOR_MINOR_VERSION
+RUN micromamba install -y --name base --file /tmp/$ENV_IN_FILENAME && \
+    micromamba clean --all --yes --force-pkgs-dirs && \
+    rm -rf /tmp/*.in
+
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+RUN sudo ln -s $(which python3) /usr/bin/python
+
+USER root
+RUN HOME_DIR="/home/${NB_USER}/licenses" \
+    && mkdir -p ${HOME_DIR} \
+    && curl -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip \
+    && unzip ${HOME_DIR}/oss_compliance.zip -d ${HOME_DIR}/ \
+    && cp ${HOME_DIR}/oss_compliance/test/testOSSCompliance /usr/local/bin/testOSSCompliance \
+    && chmod +x /usr/local/bin/testOSSCompliance \
+    && chmod +x ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh \
+    && ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh ${HOME_DIR} python \
+    && rm -rf ${HOME_DIR}/oss_compliance*
+
+USER $MAMBA_USER
+ENV PATH="/opt/conda/bin:/opt/conda/condabin:$PATH"
+WORKDIR "/home/${NB_USER}"
+ENV SHELL=/bin/bash

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -83,7 +83,8 @@ def _create_new_version_artifacts_helper(mocker, tmp_path, version):
     _create_docker_gpu_env_in_file(input_version_dir / 'gpu.env.in')
     _create_docker_cpu_env_out_file(input_version_dir / 'cpu.env.out')
     _create_docker_gpu_env_out_file(input_version_dir / 'gpu.env.out')
-    _create_docker_file(input_version_dir / 'Dockerfile')
+    os.makedirs(tmp_path / 'template')
+    _create_docker_file(tmp_path / 'template' / 'Dockerfile')
 
 
 def test_get_semver_version():
@@ -132,8 +133,10 @@ def test_create_new_version_artifacts_for_invalid_upgrade_type():
         create_patch_version_artifacts(input)
 
 
-def test_create_new_version_artifacts_for_patch_version_upgrade(mocker, tmp_path):
+@patch("os.path.relpath")
+def test_create_new_version_artifacts_for_patch_version_upgrade(rel_path, mocker, tmp_path):
     input_version = '1.2.5'
+    rel_path.side_effect = [str(tmp_path / 'template' / 'Dockerfile')]
     _create_new_version_artifacts_helper(mocker, tmp_path, input_version)
     args = CreateVersionArgs('patch', input_version)
     create_patch_version_artifacts(args)
@@ -159,8 +162,10 @@ def test_create_new_version_artifacts_for_patch_version_upgrade(mocker, tmp_path
         assert contents.find(expected_version_string) != -1
 
 
-def test_create_new_version_artifacts_for_minor_version_upgrade(mocker, tmp_path):
+@patch("os.path.relpath")
+def test_create_new_version_artifacts_for_minor_version_upgrade(rel_path, mocker, tmp_path):
     input_version = '1.2.5'
+    rel_path.side_effect = [str(tmp_path / 'template' / 'Dockerfile')]
     _create_new_version_artifacts_helper(mocker, tmp_path, input_version)
     args = CreateVersionArgs('minor', input_version)
     create_minor_version_artifacts(args)
@@ -186,8 +191,10 @@ def test_create_new_version_artifacts_for_minor_version_upgrade(mocker, tmp_path
         assert contents.find(expected_version_string) != -1
 
 
-def test_create_new_version_artifacts_for_major_version_upgrade(mocker, tmp_path):
+@patch("os.path.relpath")
+def test_create_new_version_artifacts_for_major_version_upgrade(rel_path, mocker, tmp_path):
     input_version = '1.2.5'
+    rel_path.side_effect = [str(tmp_path / 'template' / 'Dockerfile')]
     _create_new_version_artifacts_helper(mocker, tmp_path, input_version)
     args = CreateVersionArgs('major', input_version)
     create_major_version_artifacts(args)


### PR DESCRIPTION
…

*Issue #, if available:* N/A

*Description of changes:* Move Dockerfile to a new template directory and modify the version generator script to copy from that file


Note: 
* I also considered completely removing DockerFiles from the build artifacts folder. But decided against it because this template DockerFile might evolve over time. We should have any easier mechanism to audit the contents of a Dockerfile in a particular image version. Hence left the dockerfile in build artifacts folder.
* Didn't plan on moving gpu.arg_based_env.in. The reason is that : it is a env.in file and I don't expect major changes to that


*Testing:* Unit tests and generated a new patch version locally . Verified that the new patch version had the docker file in it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
