### PR TITLE
feature: Add a script for generating package staleness

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ So, if you want to stay on the latest software as and when release by Amazon Sag
 `latest-cpu` and do a `docker pull latest-cpu` when needed. If you use, say, `0.1.2-cpu`, the underlying distribution
 will remain the same over time.
 
+### Package Staleness Report
+
+If you want to generate/view the staleness report for each of the individual packages in a given 
+SageMaker distribution image version, then run the following command:
+
+```
+VERSION=<Insert SageMaker Distribution version in semver format here. example: 0.4.2>
+python ./src/main.py generate-staleness-report --target-patch-version $VERSION
+```
+
+
+
 ## Example use cases
 
 Here are some examples on how you can try out one of our images.

--- a/src/config.py
+++ b/src/config.py
@@ -8,7 +8,8 @@ _image_generator_configs = [
         },
         'image_tag_generator': '{image_version}-gpu',
         'env_out_filename': 'gpu.env.out',
-        'pytest_flags': ['--use-gpu']
+        'pytest_flags': ['--use-gpu'],
+        'image_type': 'gpu'
     },
     {
         'build_args': {
@@ -17,6 +18,7 @@ _image_generator_configs = [
         },
         'image_tag_generator': '{image_version}-cpu',
         'env_out_filename': 'cpu.env.out',
-        'pytest_flags': []
+        'pytest_flags': [],
+        'image_type': 'cpu'
     }
 ]

--- a/src/package_staleness.py
+++ b/src/package_staleness.py
@@ -1,0 +1,99 @@
+import conda.cli.python_api
+import json
+from utils import (
+    get_dir_for_version,
+    get_semver,
+    get_match_specs,
+)
+from config import _image_generator_configs
+from dependency_upgrader import _dependency_metadata
+from conda.models.match_spec import MatchSpec
+
+
+def _get_package_versions_in_upstream(target_packages_match_spec_out, target_version) \
+        -> dict[str, str]:
+    package_to_version_mapping = {}
+    is_major_version_release = target_version.minor == 0 and target_version.patch == 0
+    is_minor_version_release = target_version.patch == 0 and not is_major_version_release
+    for package in target_packages_match_spec_out:
+        # Execute a conda search api call in the linux-64 subdirectory
+        # packages such as pytorch-gpu are present only in linux-64 sub directory
+        match_spec_out = target_packages_match_spec_out[package]
+        package_version = str(match_spec_out.get("version")).removeprefix('==')
+        package_version = get_semver(package_version)
+        channel = match_spec_out.get("channel").channel_name
+        subdir_filter = '[subdir=' + match_spec_out.get('subdir') + ']'
+        search_result = conda.cli.python_api.run_command('search', channel + '::' + package +
+                                                         '>=' + str(package_version) +
+                                                         subdir_filter, '--json')
+        # Load the first result as json. The API sends a json string inside an array
+        package_metadata = json.loads(search_result[0])[package]
+        # Response is of the structure
+        # { 'package_name': [{'url':<someurl>, 'dependencies': <List of dependencies>, 'version':
+        # <version number>}, ..., {'url':<someurl>, 'dependencies': <List of dependencies>, 'version':
+        # <version number>}]
+        # We only care about the version number in the last index
+        package_version_in_conda = ''
+        if is_major_version_release:
+            latest_package_version_in_conda = package_metadata[-1]['version']
+        elif is_minor_version_release:
+            package_major_version_prefix = str(package_version.major) + "."
+            latest_package_version_in_conda = [x['version'] for x in package_metadata if
+                                        x['version'].startswith(package_major_version_prefix)][-1]
+        else:
+            package_minor_version_prefix = \
+                ".".join([str(package_version.major), str(package_version.minor)]) + "."
+            latest_package_version_in_conda = [x['version'] for x in package_metadata if
+                                        x['version'].startswith(package_minor_version_prefix)][-1]
+
+        package_to_version_mapping[package] = latest_package_version_in_conda
+    return package_to_version_mapping
+
+
+def _generate_report(package_versions_in_upstream, target_packages_match_spec_out, image_config,
+                     version):
+    print('\n# Staleness Report: ' + str(version) + '(' + image_config['image_type'] + ')\n')
+    print('Package | Current Version in the Distribution image | Latest Relevant Version in '
+          'Upstream')
+    print('---|---|---')
+    for package in package_versions_in_upstream:
+        version_in_sagemaker_distribution = \
+            str(target_packages_match_spec_out[package].get('version')).removeprefix('==')
+        if version_in_sagemaker_distribution == package_versions_in_upstream[package]:
+            print(package + '|' + version_in_sagemaker_distribution + '|' +
+                  package_versions_in_upstream[package])
+        else:
+            print('${\color{red}' + package + '}$' + '|' + version_in_sagemaker_distribution +
+                  '|' + package_versions_in_upstream[package])
+
+
+def _get_installed_package_versions_and_conda_versions(image_config, target_version_dir,
+                                                       target_version) \
+        -> (dict[str, MatchSpec], dict[str, str]):
+    env_in_file_name = image_config['build_args']['ENV_IN_FILENAME']
+    env_out_file_name = image_config['env_out_filename']
+    required_packages_from_target = get_match_specs(
+        target_version_dir + "/" + env_in_file_name
+    ).keys()
+    match_spec_out = get_match_specs(target_version_dir + "/" + env_out_file_name)
+    # We only care about packages which are present in env.in
+    # Remove Python from the dictionary, we don't want to track python version as part of our
+    # staleness report.
+    target_packages_match_spec_out = {k: v for k, v in match_spec_out.items()
+                                      if k in required_packages_from_target and k
+                                      not in _dependency_metadata}
+    latest_package_versions_in_upstream = \
+        _get_package_versions_in_upstream(target_packages_match_spec_out,
+                                             target_version)
+    return target_packages_match_spec_out, latest_package_versions_in_upstream
+
+
+def generate_package_staleness_report(args):
+    target_version = get_semver(args.target_patch_version)
+    target_version_dir = get_dir_for_version(target_version)
+    for image_config in _image_generator_configs:
+        target_packages_match_spec_out, latest_package_versions_in_upstream = \
+            _get_installed_package_versions_and_conda_versions(image_config, target_version_dir,
+                                                               target_version)
+        _generate_report(latest_package_versions_in_upstream, target_packages_match_spec_out,
+                         image_config, target_version)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,37 @@
+import os
+from semver import Version
+from conda.models.match_spec import MatchSpec
+from conda_env.specs import RequirementsSpec
+
+
+def get_dir_for_version(version: Version) -> str:
+    return os.path.relpath(f'build_artifacts/v{version.major}/v{version.major}.{version.minor}/'
+                           f'v{version.major}.{version.minor}.{version.patch}')
+
+
+def is_exists_dir_for_version(version: Version) -> bool:
+    dir_path = get_dir_for_version(version)
+    return os.path.exists(dir_path)
+
+
+def get_semver(version_str) -> Version:
+    version = Version.parse(version_str)
+    if version.prerelease is not None or version.build is not None:
+        raise Exception()
+    return version
+
+
+def read_env_file(file_path) -> RequirementsSpec:
+    return RequirementsSpec(filename=file_path)
+
+
+def get_match_specs(file_path) -> dict[str, MatchSpec]:
+    if not os.path.isfile(file_path):
+        return {}
+
+    requirement_spec = read_env_file(file_path)
+    assert len(requirement_spec.environment.dependencies) == 1
+    assert 'conda' in requirement_spec.environment.dependencies
+
+    return {MatchSpec(i).get('name'): MatchSpec(i) for i in
+            requirement_spec.environment.dependencies['conda']}

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -7,7 +7,6 @@ import pytest
 pytestmark = pytest.mark.unit
 
 from main import (
-    get_semver,
     create_and_get_semver_dir,
     _get_version_tags,
     create_major_version_artifacts,
@@ -16,6 +15,7 @@ from main import (
     build_images,
     _push_images_upstream
 )
+from utils import get_semver
 import os
 from unittest.mock import patch, Mock, MagicMock
 

--- a/test/test_package_staleness.py
+++ b/test/test_package_staleness.py
@@ -1,0 +1,87 @@
+from __future__ import absolute_import
+
+from conda.cli.python_api import run_command
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from utils import get_semver, get_match_specs
+from package_staleness import _get_installed_package_versions_and_conda_versions
+from config import _image_generator_configs
+from unittest.mock import patch, Mock, MagicMock
+
+
+def _create_env_in_docker_file(file_path):
+    with open(file_path, 'w') as env_in_file:
+        env_in_file.write(f'''# This file is auto-generated.
+conda-forge::ipykernel
+conda-forge::numpy[version=\'>=1.0.17,<2.0.0\']''')
+
+
+def _create_env_out_docker_file(file_path):
+    with open(file_path, 'w') as env_out_file:
+        env_out_file.write(f'''# This file may be used to create an environment using:
+# $ conda create --name <env> --file <this file>
+# platform: linux-64
+https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.21.3-pyh210e3f2_0.conda#8c1f6bf32a6ca81232c4853d4165ca67
+https://conda.anaconda.org/conda-forge/linux-64/numpy-1.24.2-py38h10c12cc_0.conda#05592c85b9f6931dc2df1e80c0d56294\n''')
+
+
+def test_get_match_specs(tmp_path):
+    env_out_file_path = tmp_path / 'env.out'
+    _create_env_out_docker_file(env_out_file_path)
+    match_spec_out = get_match_specs(env_out_file_path)
+    ipykernel_match_spec = match_spec_out['ipykernel']
+    assert str(ipykernel_match_spec.get('version')).removeprefix('==') == '6.21.3'
+    numpy_match_spec = match_spec_out['numpy']
+    assert str(numpy_match_spec.get('version')).removeprefix('==') == '1.24.2'
+    assert ipykernel_match_spec.get('subdir') == 'noarch'
+    assert numpy_match_spec.get('subdir') == 'linux-64'
+    assert len(match_spec_out) == 2
+    # Test bad file path
+    env_out_file_path = tmp_path / 'bad.env.out'
+    match_spec_out = get_match_specs(env_out_file_path)
+    assert len(match_spec_out) == 0
+
+
+@patch("conda.cli.python_api.run_command")
+def test_get_installed_package_versions_and_conda_versions(mock_run_command, tmp_path):
+    mock_run_command.return_value = ('{"ipykernel":[{"version": "6.21.3"}], "numpy":[{"version": '
+                                     '"1.24.3"},{"version":"1.26.0"},{"version":"2.1.0"}]}', '', 0)
+    env_in_file_path = tmp_path / 'cpu.env.in'
+    _create_env_in_docker_file(env_in_file_path)
+    env_out_file_path = tmp_path / 'cpu.env.out'
+    _create_env_out_docker_file(env_out_file_path)
+    # Validate results for patch version release
+    # _image_generator_configs[1] is for CPU
+    match_spec_out, latest_package_versions_in_conda_forge = \
+        _get_installed_package_versions_and_conda_versions(_image_generator_configs[1],
+                                                           str(tmp_path), get_semver('0.4.2'))
+    ipykernel_match_spec = match_spec_out['ipykernel']
+    assert str(ipykernel_match_spec.get('version')).removeprefix('==') == '6.21.3'
+    numpy_match_spec = match_spec_out['numpy']
+    assert str(numpy_match_spec.get('version')).removeprefix('==') == '1.24.2'
+    assert latest_package_versions_in_conda_forge['ipykernel'] == '6.21.3'
+    assert latest_package_versions_in_conda_forge['numpy'] == '1.24.3'
+    # Validate results for minor version release
+    match_spec_out, latest_package_versions_in_conda_forge = \
+        _get_installed_package_versions_and_conda_versions(_image_generator_configs[1],
+                                                           str(tmp_path), get_semver('0.5.0'))
+    ipykernel_match_spec = match_spec_out['ipykernel']
+    assert str(ipykernel_match_spec.get('version')).removeprefix('==') == '6.21.3'
+    numpy_match_spec = match_spec_out['numpy']
+    assert str(numpy_match_spec.get('version')).removeprefix('==') == '1.24.2'
+    assert latest_package_versions_in_conda_forge['ipykernel'] == '6.21.3'
+    # Only for numpy there is a new minor version available.
+    assert latest_package_versions_in_conda_forge['numpy'] == '1.26.0'
+    # Validate results for major version release
+    match_spec_out, latest_package_versions_in_conda_forge = \
+        _get_installed_package_versions_and_conda_versions(_image_generator_configs[1],
+                                                           str(tmp_path), get_semver('1.0.0'))
+    ipykernel_match_spec = match_spec_out['ipykernel']
+    assert str(ipykernel_match_spec.get('version')).removeprefix('==') == '6.21.3'
+    numpy_match_spec = match_spec_out['numpy']
+    assert str(numpy_match_spec.get('version')).removeprefix('==') == '1.24.2'
+    assert latest_package_versions_in_conda_forge['ipykernel'] == '6.21.3'
+    # Only for numpy there is a new major version available.
+    assert latest_package_versions_in_conda_forge['numpy'] == '2.1.0'


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Added a script for generating package staleness.

The script generates the report in a Markdown format.

*Testing:* Unit tests + Manual verification for 0.4.1

Ran the following command: 
```
python ./src/package_staleness.py generate-report --target-patch-version 0.4.1
```

And got the following output:


# Staleness Report: 0.4.1(cpu)

Package | Current Version in the Distribution image | Latest Version in Conda Forge
---|---|---
matplotlib|3.7.2|3.7.2
${\color{red}boto3}$|1.28.20|1.28.22
${\color{red}jupyterlab}$|3.6.5|4.0.4
${\color{red}keras}$|2.12.0|2.13.1
${\color{red}sagemaker-python-sdk}$|2.173.0|2.175.0
${\color{red}ipython}$|8.12.2|8.14.0
pandas|2.0.3|2.0.3
scikit-learn|1.3.0|1.3.0
${\color{red}scipy}$|1.10.1|1.11.1
conda|23.7.2|23.7.2
jinja2|3.1.2|3.1.2
torchvision|0.15.2|0.15.2
pip|23.2.1|23.2.1
${\color{red}python}$|3.8.17|3.11.4
tensorflow|2.12.1|2.12.1
ipywidgets|8.1.0|8.1.0
pytorch|2.0.0|2.0.0
${\color{red}numpy}$|1.24.4|1.25.2
py-xgboost-cpu|1.7.6|1.7.6

# Staleness Report: 0.4.1(gpu)

Package | Current Version in the Distribution image | Latest Version in Conda Forge
---|---|---
matplotlib|3.7.2|3.7.2
${\color{red}boto3}$|1.28.20|1.28.22
${\color{red}jupyterlab}$|3.6.5|4.0.4
${\color{red}keras}$|2.12.0|2.13.1
pytorch-gpu|2.0.0|2.0.0
${\color{red}sagemaker-python-sdk}$|2.173.0|2.175.0
${\color{red}ipython}$|8.12.2|8.14.0
pandas|2.0.3|2.0.3
scikit-learn|1.3.0|1.3.0
${\color{red}scipy}$|1.10.1|1.11.1
conda|23.7.2|23.7.2
jinja2|3.1.2|3.1.2
torchvision|0.15.2|0.15.2
pip|23.2.1|23.2.1
${\color{red}python}$|3.8.17|3.11.4
tensorflow|2.12.1|2.12.1
py-xgboost-gpu|1.7.6|1.7.6
ipywidgets|8.1.0|8.1.0
${\color{red}numpy}$|1.24.4|1.25.2



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
