### PR TITLE
feature: Support generating prerelease versions

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -5,18 +5,24 @@ from conda_env.specs import RequirementsSpec
 
 
 def get_dir_for_version(version: Version) -> str:
+    version_prerelease_suffix = f'/v{version.major}.{version.minor}.{version.patch}-' \
+                                f'{version.prerelease}' if version.prerelease else ''
     return os.path.relpath(f'build_artifacts/v{version.major}/v{version.major}.{version.minor}/'
-                           f'v{version.major}.{version.minor}.{version.patch}')
+                           f'v{version.major}.{version.minor}.{version.patch}'
+                           f'{version_prerelease_suffix}')
 
 
 def is_exists_dir_for_version(version: Version) -> bool:
     dir_path = get_dir_for_version(version)
-    return os.path.exists(dir_path)
+    # Also validate whether this directory is not generated due to any pre-release builds
+    # This can be validated by checking whether {cpu/gpu}.env.{in/out}/Dockerfile exists in the
+    # directory.
+    return os.path.exists(dir_path) and os.path.exists(dir_path + "/" + 'Dockerfile')
 
 
 def get_semver(version_str) -> Version:
     version = Version.parse(version_str)
-    if version.prerelease is not None or version.build is not None:
+    if version.build is not None:
         raise Exception()
     return version
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*  Support generating prerelease versions

* Prevented creation of new major/minor/patch versions from a given prerelease version
* Supported passing a prerelease identifier to create major/minor/patch version artifacts method
* If prerelease identifier is passed, then an additional nested directory will be created inside the regular directory . The name of this new nested directory will be v"major"."minor"."patch"-"prerelease"
* Modified the tag generation logic
   * if the given version during the build command is a prerelease version, then just return that version as a tag
   * Modified the existing "is_exists_dir_for_version" method to also check whether that directory doesn't just have a prerelease version. This is done by checking whether that directory has a docker file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
