### PR TITLE
feature: Print Docker build failure logs

### DIFF
--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -17,11 +17,10 @@ RUN usermod "--login=${NB_USER}" "--home=/home/${NB_USER}" --move-home "-u ${NB_
     echo "${NB_USER}" > "/etc/arg_mamba_user" && \
     :
 ENV MAMBA_USER=$NB_USER
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends sudo gettext-base wget curl awscli unzip git && \
-    # We just install tzdata below but leave default time zone as UTC. This helps packages like Pandas to function correctly.
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \
+    apt-get install -y --no-install-recommends sudo gettext-base wget curl awscli unzip git tzdata && \
     chmod g+w /etc/passwd && \
     echo "ALL    ALL=(ALL)    NOPASSWD:    ALL" >> /etc/sudoers && \
     # Note that we do NOT run `rm -rf /var/lib/apt/lists/*` here. If we did, anyone building on top of our images will

--- a/test/test_dockerfile_based_harness.py
+++ b/test/test_dockerfile_based_harness.py
@@ -2,6 +2,7 @@ import subprocess
 
 import docker
 import pytest
+from docker.errors import BuildError
 pytestmark = pytest.mark.slow
 
 
@@ -19,8 +20,16 @@ _docker_client = docker.from_env()
                                              "tensorflow.examples.Dockerfile"])
 def test_dockerfiles(dockerfile_path: str, local_image_id: str, use_gpu: bool):
     print(f'Will start running test for: {dockerfile_path} against: {local_image_id}')
-    image, _ = _docker_client.images.build(path='test/test_artifacts', dockerfile=dockerfile_path,
-                                           rm=True, buildargs={'COSMOS_IMAGE': local_image_id})
+    try:
+        image, _ = _docker_client.images.build(path='test/test_artifacts',
+                                               dockerfile=dockerfile_path,
+                                               rm=True, buildargs={'COSMOS_IMAGE': local_image_id})
+    except BuildError as e:
+        for line in e.build_log:
+            if 'stream' in line:
+                print(line['stream'].strip())
+        # After printing the logs raise the exception (which is the old behavior)
+        raise
     print(f'Built a test image: {image.id}, will now execute its default CMD.')
     # Execute the new image once. Mark the current test successful/failed based on container's exit code. (We assume
     # that the image would have supplied the right entrypoint.
@@ -33,7 +42,10 @@ def test_dockerfiles(dockerfile_path: str, local_image_id: str, use_gpu: bool):
     # We assume that the image above would have supplied the right entrypoint, so we just run it as is. If the container
     # didn't execute successfully, the Docker client below will throw an error and fail the test.
     # A consequence of this design decision is that any test assertions should go inside the container's entry-point.
-    _docker_client.containers.run(image=image.id, detach=False, auto_remove=True, device_requests=device_requests)
+    _docker_client.containers.run(image=image.id, detach=False, auto_remove=True,
+                                  device_requests=device_requests, stderr=True)
+    # Remove the test docker image after running the test.
+    _docker_client.images.remove(image=image.id, force=True)
 
 
 # The following is a simple function to check whether the local machine has at least 1 GPU and some Nvidia driver


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Print Docker build failure logs
* Also seems like awscli installation now requires time zone information. Because of this, we are not able to build our docker images. Verified that with running apt-get install awscli. So moved the "DEBIAN_FRONTEND=noninteractive" as a docker environment variable
* Also saved disk space by deleting test images after test


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
