### PR TITLE
fix: fix env.in version constraints for major version upgrade

### DIFF
--- a/src/dependency_upgrader.py
+++ b/src/dependency_upgrader.py
@@ -18,9 +18,9 @@ def _get_dependency_upper_bound_for_semver(lower_bound: str, runtime_upgrade_typ
     if runtime_upgrade_type == _MAJOR:
         return ''   # No upper bound.
     elif runtime_upgrade_type == _MINOR:
-        return f'<{lower_semver.bump_major()}'
+        return f',<{lower_semver.bump_major()}'
     elif runtime_upgrade_type == _PATCH:
-        return f'<{lower_semver.bump_minor()}'
+        return f',<{lower_semver.bump_minor()}'
     else:
         raise Exception()
 
@@ -30,9 +30,9 @@ def _get_dependency_upper_bound_for_pythonesque(lower_bound: str, runtime_upgrad
     if runtime_upgrade_type == _MAJOR:
         return ''  # No upper bound.
     elif runtime_upgrade_type == _MINOR:
-        return f'<{lower_semver.bump_minor()}'
+        return f',<{lower_semver.bump_minor()}'
     elif runtime_upgrade_type == _PATCH:
-        return f'<{lower_semver.bump_minor()}'
+        return f',<{lower_semver.bump_minor()}'
     else:
         raise Exception()
 

--- a/src/main.py
+++ b/src/main.py
@@ -105,7 +105,7 @@ def _create_new_version_conda_specs(base_version_dir, new_version_dir, runtime_v
                                                                               min_version_inclusive,
                                                                               runtime_version_upgrade_type)
 
-            out.append(f"{channel}::{package_name}[version='>={min_version_inclusive},{max_version_str}']")
+            out.append(f"{channel}::{package_name}[version='>={min_version_inclusive}{max_version_str}']")
 
     with open(f'{new_version_dir}/{env_in_filename}', 'w') as f:
         f.write("# This file is auto-generated.\n")

--- a/test/test_dependency_upgrader.py
+++ b/test/test_dependency_upgrader.py
@@ -15,18 +15,18 @@ from dependency_upgrader import (
 
 def test_get_dependency_upper_bound_for_runtime_upgrade():
     # case 1: Runtime upgrade type is MINOR, dependency name is python => use pythonesque
-    assert _get_dependency_upper_bound_for_runtime_upgrade('python', '1.2.5', _MINOR) == '<1.3.0'
+    assert _get_dependency_upper_bound_for_runtime_upgrade('python', '1.2.5', _MINOR) == ',<1.3.0'
     # case 1: Runtime upgrade type is MINOR, dependency name is node => use semver
-    assert _get_dependency_upper_bound_for_runtime_upgrade('node', '1.2.5', _MINOR) == '<2.0.0'
+    assert _get_dependency_upper_bound_for_runtime_upgrade('node', '1.2.5', _MINOR) == ',<2.0.0'
 
 
 def test_get_dependency_upper_bound_for_semver():
     # case 1: Runtime upgrade type is MAJOR.
     assert _get_dependency_upper_bound_for_semver('1.2.5', _MAJOR) == ''
     # case 2: Runtime upgrade type is MINOR.
-    assert _get_dependency_upper_bound_for_semver('1.2.5', _MINOR) == '<2.0.0'
+    assert _get_dependency_upper_bound_for_semver('1.2.5', _MINOR) == ',<2.0.0'
     # case 3: Runtime upgrade type is PATCH.
-    assert _get_dependency_upper_bound_for_semver('1.2.5', _PATCH) == '<1.3.0'
+    assert _get_dependency_upper_bound_for_semver('1.2.5', _PATCH) == ',<1.3.0'
     # case 4: Throw exception for any other runtime_upgrade_type
     with pytest.raises(Exception):
         _get_dependency_upper_bound_for_semver('1.2.5', 'prerelease')
@@ -36,9 +36,9 @@ def test_get_dependency_upper_bound_for_pythonesque():
     # case 1: Runtime upgrade type is MAJOR.
     assert _get_dependency_upper_bound_for_pythonesque('1.2.5', _MAJOR) == ''
     # case 2: Runtime upgrade type is MINOR.
-    assert _get_dependency_upper_bound_for_pythonesque('1.2.5', _MINOR) == '<1.3.0'
+    assert _get_dependency_upper_bound_for_pythonesque('1.2.5', _MINOR) == ',<1.3.0'
     # case 3: Runtime upgrade type is PATCH. For pythonesque, we will bump minor version.
-    assert _get_dependency_upper_bound_for_pythonesque('1.2.5', _PATCH) == '<1.3.0'
+    assert _get_dependency_upper_bound_for_pythonesque('1.2.5', _PATCH) == ',<1.3.0'
     # case 4: Throw exception for any other runtime_upgrade_type
     with pytest.raises(Exception):
         _get_dependency_upper_bound_for_pythonesque('1.2.5', 'prerelease')

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -254,13 +254,13 @@ def _create_and_assert_major_version_upgrade(rel_path, mocker, tmp_path,
         contents = f.read()
         # version of ipykernel in cpu.env.out is 6.21.3
         # so we expect the version string to be >=6.21.3,
-        expected_version_string = '>=6.21.3,\''
+        expected_version_string = '>=6.21.3\''
         assert contents.find(expected_version_string) != -1
     with open(new_version_dir / 'gpu.env.in', 'r') as f:
         contents = f.read()
         # version of numpy in gpu.env.out is 1.24.2
         # so we expect the version string to be >=1.24.2,
-        expected_version_string = '>=1.24.2,\''
+        expected_version_string = '>=1.24.2\''
         assert contents.find(expected_version_string) != -1
 
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/sagemaker-distribution/issues/51

*Description of changes:*
During a major version release, I noticed that env.in file has an additional comma in the version constraints. Removed that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
