### PR TITLE
fix: Installing awscli now requires timezone information.

### DIFF
--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -19,9 +19,9 @@ RUN usermod "--login=${NB_USER}" "--home=/home/${NB_USER}" --move-home "-u ${NB_
 ENV MAMBA_USER=$NB_USER
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends sudo gettext-base wget curl awscli unzip git && \
+    apt-get install -y --no-install-recommends sudo gettext-base wget curl unzip git && \
     # We just install tzdata below but leave default time zone as UTC. This helps packages like Pandas to function correctly.
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata awscli && \
     chmod g+w /etc/passwd && \
     echo "ALL    ALL=(ALL)    NOPASSWD:    ALL" >> /etc/sudoers && \
     # Note that we do NOT run `rm -rf /var/lib/apt/lists/*` here. If we did, anyone building on top of our images will


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Without this change, the docker image build is not getting completed and it is waiting for user input.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
