### PR TITLE
feature: Added support for not modifying conda package closure during rebuild

### DIFF
--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && \
 RUN echo "source /usr/local/bin/_activate_current_env.sh" | tee --append /etc/profile
 
 USER $MAMBA_USER
-COPY --chown=$MAMBA_USER:$MAMBA_USER *.in /tmp/
+COPY --chown=$MAMBA_USER:$MAMBA_USER $ENV_IN_FILENAME *.in /tmp/
 
 # Make sure that $ENV_IN_FILENAME has a newline at the end before the `tee` command runs. Otherwise, nasty things
 # will happen.


### PR DESCRIPTION


*Issue #, if available:* N/A

*Description of changes:* Added support for not modifying conda package closure during rebuild.

This is needed for Github action. One Github action might generate the PR for a new version release, but another github action might be responsible for publishing the image. So when the second github action is running, it might fetch the latest versions of python packages. 

This change will prevent that (unless a force argument is passed)

*Testing:*

* unit tests
* verified the behavior with 0.4.0, it didn't modify the env.out files
* ran the same command again with "force" for 0.4.0, it modified the env.out files

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
