### PR TITLE
feature: Printed logs for Docker build/run failures

### DIFF
--- a/test/test_dockerfile_based_harness.py
+++ b/test/test_dockerfile_based_harness.py
@@ -2,6 +2,7 @@ import subprocess
 
 import docker
 import pytest
+from docker.errors import BuildError, ContainerError
 pytestmark = pytest.mark.slow
 
 
@@ -19,8 +20,16 @@ _docker_client = docker.from_env()
                                              "tensorflow.examples.Dockerfile"])
 def test_dockerfiles(dockerfile_path: str, local_image_id: str, use_gpu: bool):
     print(f'Will start running test for: {dockerfile_path} against: {local_image_id}')
-    image, _ = _docker_client.images.build(path='test/test_artifacts', dockerfile=dockerfile_path,
-                                           rm=True, buildargs={'COSMOS_IMAGE': local_image_id})
+    try:
+        image, _ = _docker_client.images.build(path='test/test_artifacts',
+                                               dockerfile=dockerfile_path,
+                                               rm=True, buildargs={'COSMOS_IMAGE': local_image_id})
+    except BuildError as e:
+        for line in e.build_log:
+            if 'stream' in line:
+                print(line['stream'].strip())
+        # After printing the logs raise the exception (which is the old behavior)
+        raise
     print(f'Built a test image: {image.id}, will now execute its default CMD.')
     # Execute the new image once. Mark the current test successful/failed based on container's exit code. (We assume
     # that the image would have supplied the right entrypoint.
@@ -33,7 +42,16 @@ def test_dockerfiles(dockerfile_path: str, local_image_id: str, use_gpu: bool):
     # We assume that the image above would have supplied the right entrypoint, so we just run it as is. If the container
     # didn't execute successfully, the Docker client below will throw an error and fail the test.
     # A consequence of this design decision is that any test assertions should go inside the container's entry-point.
-    _docker_client.containers.run(image=image.id, detach=False, auto_remove=True, device_requests=device_requests)
+    try:
+        _docker_client.containers.run(image=image.id, detach=False, auto_remove=True,
+                                      device_requests=device_requests)
+    except ContainerError as e:
+        print(e.container.logs().decode('utf-8'))
+        # After printing the logs, raise the exception (which is the old behavior)
+        raise
+    finally:
+        # Remove the test docker image after running the test.
+        _docker_client.images.remove(image=image.id, force=True)
 
 
 # The following is a simple function to check whether the local machine has at least 1 GPU and some Nvidia driver


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
* Printed logs during Docker  image build/container run failures
* Deleted test image after the test is ran

*Testing:*
Verified this by testing with an existing image and it printed scipy container logs (after test failures)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
