### PR TITLE
feature: Add more flexibility to docker based tests so that we can pass different dockerfiles for different image types

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 markers =
-    slow: For running tests on docker images to verify package installations.
+    gpu: For running tests on GPU docker images to verify package installations.
+    cpu: For running tests on CPU docker images to verify package installations.
     unit: For running unit tests
 pythonpath = src/
 addopts = -n 2

--- a/src/main.py
+++ b/src/main.py
@@ -160,7 +160,8 @@ def _push_images_upstream(image_versions_to_push: list[dict[str, str]], region: 
 def _test_local_images(image_ids_to_test: list[str]):
     assert len(image_ids_to_test) == len(_image_generator_configs)
     for (image_id, config) in zip(image_ids_to_test, _image_generator_configs):
-        exit_code = pytest.main(['-n', '2', '-m', 'slow', '--local-image-id', image_id, *config['pytest_flags']])
+        exit_code = pytest.main(['-n', '2', '-m', config['image_type'], '--local-image-id',
+                                 image_id, *config['pytest_flags']])
 
         assert exit_code == 0, f'Tests failed with exit code: {exit_code} against: {image_id}'
 


### PR DESCRIPTION


*Issue #, if available:* N/A

*Description of changes:*
* Add more flexibility to docker based tests so that we can pass different dockerfiles for different image types

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
