### PR TITLE
feature: add Jupyter Server and supervisord config to template

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ docker run -it \
 
 (If you have access to Nvidia GPUs, you can pass `--gpus=all` to the Docker command.)
 
+In the image, we also have entrypoints built in, that automatically starts IDE server and automatically restarts
+IDE server in case of minor IDE server interruptions or crashes. For example, to start JupyterLab server using the
+entrypoint built in:
+```shell
+export ECR_IMAGE_ID='INSERT_IMAGE_YOU_WANT_TO_USE'
+docker run -it \
+    -p 8888:8888 \
+    --entrypoint entrypoint-jupyter-server \
+    --user `id -u`:`id -g` \
+    -v `pwd`/sample-notebooks:/home/sagemaker-user/sample-notebooks \
+    $ECR_IMAGE_ID
+```
+
 In the console output, you'll then see a URL similar to `http://127.0.0.1:8888/lab?token=foo`. Just open that URL in
 your browser, create a Jupyter Lab notebook or open a terminal, and start hacking.
 

--- a/src/main.py
+++ b/src/main.py
@@ -81,6 +81,8 @@ def _copy_static_files(base_version_dir, new_version_dir):
         shutil.copy2(f, new_version_dir)
     for f in glob.glob(os.path.relpath(f'template/Dockerfile')):
         shutil.copy2(f, new_version_dir)
+    for f in glob.glob(os.path.relpath(f'template/dirs')):
+        shutil.copytree(f, os.path.join(new_version_dir, 'dirs'))
 
 
 def _create_new_version_conda_specs(base_version_dir, new_version_dir, runtime_version_upgrade_type,

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -5,9 +5,14 @@ ARG CUDA_MAJOR_MINOR_VERSION=''
 ARG ENV_IN_FILENAME
 ARG ARG_BASED_ENV_IN_FILENAME
 
+ARG AMZN_BASE="/opt/amazon/sagemaker"
+ARG DIRECTORY_TREE_STAGE_DIR="${AMZN_BASE}/dir-staging"
+
 ARG NB_USER="sagemaker-user"
 ARG NB_UID=1000
 ARG NB_GID=100
+
+ENV SAGEMAKER_LOGGING_DIR="/var/log/sagemaker/"
 
 USER root
 RUN usermod "--login=${NB_USER}" "--home=/home/${NB_USER}" --move-home "-u ${NB_UID}" "${MAMBA_USER}" && \
@@ -19,7 +24,7 @@ RUN usermod "--login=${NB_USER}" "--home=/home/${NB_USER}" --move-home "-u ${NB_
 ENV MAMBA_USER=$NB_USER
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends sudo gettext-base wget curl unzip git && \
+    apt-get install -y --no-install-recommends sudo gettext-base wget curl unzip git rsync && \
     # We just install tzdata below but leave default time zone as UTC. This helps packages like Pandas to function correctly.
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata awscli && \
     chmod g+w /etc/passwd && \
@@ -57,6 +62,20 @@ RUN HOME_DIR="/home/${NB_USER}/licenses" \
     && chmod +x ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh \
     && ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh ${HOME_DIR} python \
     && rm -rf ${HOME_DIR}/oss_compliance*
+
+# Merge in OS directory tree contents.
+RUN mkdir -p ${DIRECTORY_TREE_STAGE_DIR}
+COPY dirs/ ${DIRECTORY_TREE_STAGE_DIR}/
+RUN rsync -a ${DIRECTORY_TREE_STAGE_DIR}/ / && \
+    rm -rf ${DIRECTORY_TREE_STAGE_DIR}
+
+# Create logging directories for supervisor
+RUN mkdir -p $SAGEMAKER_LOGGING_DIR && \
+    chmod a+rw $SAGEMAKER_LOGGING_DIR
+
+# Create supervisord runtime directory
+RUN mkdir -p /var/run/supervisord && \
+    chmod a+rw /var/run/supervisord
 
 USER $MAMBA_USER
 ENV PATH="/opt/conda/bin:/opt/conda/condabin:$PATH"

--- a/template/dirs/etc/conda/.condarc
+++ b/template/dirs/etc/conda/.condarc
@@ -1,0 +1,6 @@
+envs_dirs:
+   - ~/.conda/envs
+   - /opt/conda/envs
+pkgs_dirs:
+  - ~/.conda/pkgs
+  - /opt/conda/pkgs

--- a/template/dirs/etc/jupyter/jupyter_server_config.py
+++ b/template/dirs/etc/jupyter/jupyter_server_config.py
@@ -1,0 +1,24 @@
+# Default Jupyter server config
+# Note: those config can be overridden by user-level configs. 
+
+from nb_conda_kernels import CondaKernelSpecManager
+
+c.ServerApp.terminado_settings = { 'shell_command': ['/bin/bash'] }
+c.ServerApp.tornado_settings = { 'compress_response': True }
+
+# Do not delete files to trash. Instead, permanently delete files. 
+c.FileContentsManager.delete_to_trash = False
+
+# Allow deleting non-empty directory via file browser
+# Related documentation: https://github.com/jupyter-server/jupyter_server/blob/main/jupyter_server/services/contents/filemanager.py#L125-L129
+c.FileContentsManager.always_delete_dir = True
+
+# Enable `allow_hidden` by default, so hidden files are accessible via Jupyter server
+# Related documentation: https://jupyterlab.readthedocs.io/en/stable/user/files.html#displaying-hidden-files
+c.ContentsManager.allow_hidden = True
+
+# Kernel manager configurations
+# Use Conda kernelspec managers, so that kernels installed in different conda
+# environments can be detected and used in Jupyter
+c.ServerApp.kernel_spec_manager_class=CondaKernelSpecManager
+c.CondaKernelSpecManager.conda_only = True

--- a/template/dirs/etc/supervisor/conf.d/supervisord.conf
+++ b/template/dirs/etc/supervisor/conf.d/supervisord.conf
@@ -1,0 +1,27 @@
+[supervisord]
+nodaemon=true
+
+pidfile=/var/run/supervisord/supervisord.pid
+logfile=%(ENV_SAGEMAKER_LOGGING_DIR)s/supervisord/supervisord.log
+logfile_maxbytes=5MB
+logfile_backups=10
+redirect_stderr=true
+
+[unix_http_server]
+file=/var/run/supervisord/supervisor.sock
+chmod=0700
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisord/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[program:jupyterlabserver]
+directory=%(ENV_HOME)s
+command=start-jupyter-server
+stopasgroup=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/template/dirs/usr/local/bin/entrypoint-jupyter-server
+++ b/template/dirs/usr/local/bin/entrypoint-jupyter-server
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Generate and execute the shell code to modifies shell variables to include
+# micromamba commands (e.g. using `micromamba activate` to activate environments)
+eval "$(micromamba shell hook --shell=bash)"
+
+# Activate conda environment 'base', where supervisord is installed
+micromamba activate base
+
+# Start supervisord with supervisord configuration
+# Since program 'jupyterlabserver' autostarts by default, it will be started
+# automatically along with supervisord
+mkdir -p $SAGEMAKER_LOGGING_DIR/supervisord
+exec supervisord -c /etc/supervisor/conf.d/supervisord.conf -n

--- a/template/dirs/usr/local/bin/restart-jupyter-server
+++ b/template/dirs/usr/local/bin/restart-jupyter-server
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+echo "Restarting the Jupyter server. This page should refresh in a few seconds. Note that any terminals will be closed."
+echo "If this page doesn't refresh after a few seconds, try reloading your browser window."
+echo "Restarting now..."
+nohup supervisorctl -c /etc/supervisor/conf.d/supervisord.conf restart jupyterlabserver > /dev/null 2>&1 &

--- a/template/dirs/usr/local/bin/start-jupyter-server
+++ b/template/dirs/usr/local/bin/start-jupyter-server
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+eval "$(micromamba shell hook --shell=bash)"
+
+# Activate conda environment 'base', which is the default environment for Cosmos
+micromamba activate base
+
+# Start Jupyter server
+jupyter lab --ip 0.0.0.0 --port 8888 \
+  --ServerApp.token='' \
+  --ServerApp.allow_origin='*'


### PR DESCRIPTION
*Description of changes:*

* Add default config for Jupyter server
* Add script to start Jupyter server
* Add conda config to install new customer-managed environments under home directory by default
* Add supervisord to manage the Jupyter server process

To start the docker container with Jupyter server running:

```
docker run -p 8888:8888 <image-name> --entrypoint entrypoint-jupyter-server
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
