### PR TITLE
feature: use specific base_url for Jupyter server if SAGEMAKER_APP_TYPE is set

### DIFF
--- a/build_artifacts/v1/v1.0/v1.0.0/v1.0.0-beta/dirs/usr/local/bin/start-jupyter-server
+++ b/build_artifacts/v1/v1.0/v1.0.0/v1.0.0-beta/dirs/usr/local/bin/start-jupyter-server
@@ -7,6 +7,16 @@ eval "$(micromamba shell hook --shell=bash)"
 micromamba activate base
 
 # Start Jupyter server
-jupyter lab --ip 0.0.0.0 --port 8888 \
-  --ServerApp.token='' \
-  --ServerApp.allow_origin='*'
+if [ -n "$SAGEMAKER_APP_TYPE" ]; then
+  # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
+  # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
+  SAGEMAKER_APP_TYPE_LOWERCASE=$(echo $SAGEMAKER_APP_TYPE | tr '[:upper:]' '[:lower:]')
+  jupyter lab --ip 0.0.0.0 --port 8888 \
+    --ServerApp.base_url="/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
+    --ServerApp.token='' \
+    --ServerApp.allow_origin='*'
+else
+  jupyter lab --ip 0.0.0.0 --port 8888 \
+    --ServerApp.token='' \
+    --ServerApp.allow_origin='*'
+fi

--- a/template/dirs/usr/local/bin/start-jupyter-server
+++ b/template/dirs/usr/local/bin/start-jupyter-server
@@ -7,6 +7,16 @@ eval "$(micromamba shell hook --shell=bash)"
 micromamba activate base
 
 # Start Jupyter server
-jupyter lab --ip 0.0.0.0 --port 8888 \
-  --ServerApp.token='' \
-  --ServerApp.allow_origin='*'
+if [ -n "$SAGEMAKER_APP_TYPE" ]; then
+  # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
+  # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
+  SAGEMAKER_APP_TYPE_LOWERCASE=$(echo $SAGEMAKER_APP_TYPE | tr '[:upper:]' '[:lower:]')
+  jupyter lab --ip 0.0.0.0 --port 8888 \
+    --ServerApp.base_url="/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
+    --ServerApp.token='' \
+    --ServerApp.allow_origin='*'
+else
+  jupyter lab --ip 0.0.0.0 --port 8888 \
+    --ServerApp.token='' \
+    --ServerApp.allow_origin='*'
+fi


### PR DESCRIPTION
*Description of changes:*

* If SAGEMAKER_APP_TYPE env variable is set, use /<app-type-in-lower-case>/default as the base URI for Jupyter server
* SageMaker will require the base URL of Jupyter server to be set to include app type for the image to be used by SageMaker apps.
* Tested with `docker run -p 8888:8888 --env SAGEMAKER_APP_TYPE=Savitur --entrypoint entrypoint-jupyter-server` and confirmed base URI is correctly set
* Tested with `docker run -p 8888:8888 --entrypoint entrypoint-jupyter-server` and confirmed base URI is not set

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
