### PR TITLE
Ensure images are named and tagged even if `skip-tests`

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -231,8 +231,7 @@ def _build_local_images(target_version: Version, target_ecr_repo_list: list[str]
                 for t in image_tags_to_apply:
                     image.tag(target_ecr_repo, tag=t)
                     generated_image_versions.append({'repository': target_ecr_repo, 'tag': t})
-
-        if not skip_tests:
+        else:
             # Tag the image for testing
             image.tag('localhost/sagemaker-distribution',
                       config['image_tag_generator'].format(image_version=str(target_version)))


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* When `--skip-tests` is passed to `src/main.py build`, the resulting images lack names and tags. This results in the fairly obscure output:

```
% docker image ls
REPOSITORY                               TAG                 IMAGE ID       CREATED          SIZE
<none>                                   <none>              30a5081a041d   5 days ago       4.4GB
<none>                                   <none>              0f5ce882b5cd   5 days ago       12.1GB
```

This PR modifies the logic to always name and tag the images regardless of `skip_tests`. The tests are skipped anyways even if the images are named and tagged, so this should be a very safe change.

~~This is targeting the `1.0.0-beta` branch. I can port this to the `main` branch if this PR is accepted.~~ Spoke to @balajisankar15, who indicated that this should go into `main`, after which `1.0.0-beta` should then be rebased onto `main`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
