### PR TITLE
Add jupyter-scheduler

### DIFF
--- a/build_artifacts/v1/v1.0/v1.0.0/v1.0.0-beta/cpu.env.in
+++ b/build_artifacts/v1/v1.0/v1.0.0/v1.0.0-beta/cpu.env.in
@@ -21,6 +21,13 @@ conda-forge::sagemaker-python-sdk[version='>=2.173.0,']
 conda-forge::supervisor[version='>=4,']
 conda-forge::autogluon[version='>=0.8.2,']
 conda-forge::jupyter-ai[version='>=2.2.0,']
+conda-forge::jupyter-scheduler[version='>=2.2.0,']
+#####################################################################
+# jupyter_core 5.3.2+ breaks compatibility w/ scheduler.
+# This block can be removed once the bug is fixed.
+# See: https://github.com/jupyter-server/jupyter-scheduler/issues/435
+conda-forge::jupyter_core[version='>=5,<=5.3.1']
+#####################################################################
 conda-forge::jupyter-lsp[version='>=2.2.0,']
 conda-forge::python-lsp-server[version='>=1.8.2,']
 conda-forge::notebook[version='>=7.0.0,']

--- a/build_artifacts/v1/v1.0/v1.0.0/v1.0.0-beta/gpu.env.in
+++ b/build_artifacts/v1/v1.0/v1.0.0/v1.0.0-beta/gpu.env.in
@@ -21,6 +21,13 @@ conda-forge::sagemaker-python-sdk[version='>=2.173.0,']
 conda-forge::supervisor[version='>=4,']
 conda-forge::autogluon[version='>=0.8.2,']
 conda-forge::jupyter-ai[version='>=2.2.0,']
+conda-forge::jupyter-scheduler[version='>=2.2.0,']
+#####################################################################
+# jupyter_core 5.3.2+ breaks compatibility w/ scheduler.
+# This block can be removed once the bug is fixed.
+# See: https://github.com/jupyter-server/jupyter-scheduler/issues/435
+conda-forge::jupyter_core[version='>=5,<=5.3.1']
+#####################################################################
 conda-forge::jupyter-lsp[version='>=2.2.0,']
 conda-forge::python-lsp-server[version='>=1.8.2,']
 conda-forge::notebook[version='>=7.0.0,']


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Adds `jupyter-scheduler`.

This PR introduces `jupyter-scheduler` to the image. I've verified the functionality directly by entering the container and recording a demo video of the testing I performed.

## Demo

https://github.com/aws/sagemaker-distribution/assets/44106031/6c51425f-bba2-4138-ae8d-4bb070149868

Proof that scheduled notebook jobs ("Run on a schedule") work as well:

<img width="1018" alt="Screenshot 2023-10-19 at 1 21 47 PM" src="https://github.com/aws/sagemaker-distribution/assets/44106031/880c67c9-bf0f-4c16-b800-fda92564a270">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
