### PR TITLE
Fix keras tests for 0.9.0

### DIFF
--- a/test/test_artifacts/v0/keras.test.Dockerfile
+++ b/test/test_artifacts/v0/keras.test.Dockerfile
@@ -13,11 +13,6 @@ ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/opt/conda
 
 WORKDIR "keras-io/guides"
 
-# Checkout a specific commit known to be compatible with the runtime's current version of TensorFlow.
-# keras-io made backwards incompatible changes that broke these tests. Pinning at this commit for now
-# at least until the runtime's TensorFlow dependency is upgraded to the next minor version
-RUN git checkout 861b59747b43ce326bb0a12384a07d6632249901
-
 COPY --chown=$MAMBA_USER:$MAMBA_USER scripts/run_keras_tests.sh .
 RUN chmod +x run_keras_tests.sh
 # Run tests in run_keras_tests.sh


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* keras was previously pinned to be compatible with older version. It's upgraded to 2.13 in 0.9.0, and this means we need to remove the pinning


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
