### PR TITLE
fix: Fix autogluon tests for codebuild

### DIFF
--- a/test/test_artifacts/v1/scripts/run_autogluon_tests.sh
+++ b/test/test_artifacts/v1/scripts/run_autogluon_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-AUTOGLUON_VERSION=$(micromamba list | grep autogluon | tr -s ' ' | cut -d ' ' -f 3)
+AUTOGLUON_VERSION=$(micromamba list | grep autogluon | tr -s ' ' | cut -d ' ' -f 3 | head -n 1)
 git checkout tags/v$AUTOGLUON_VERSION
 
 # Run autogluon quick start as end-to-end check

--- a/test/test_dockerfile_based_harness.py
+++ b/test/test_dockerfile_based_harness.py
@@ -126,7 +126,8 @@ def _validate_docker_images(dockerfile_path: str, required_packages: List[str],
         image, _ = _docker_client.images.build(path=test_artifacts_path,
                                                dockerfile=dockerfile_path,
                                                tag=dockerfile_path.lower().replace('.', '-'),
-                                               rm=True, buildargs={'COSMOS_IMAGE': docker_image_identifier})
+                                               rm=True, buildargs={'COSMOS_IMAGE': docker_image_identifier},
+                                               shm_size='256m')
     except BuildError as e:
         for line in e.build_log:
             if 'stream' in line:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* When running autogluon gpu tests on codebuild, saw failure due to kernel dying. Upon investigation found we run out of shared memory, so up the shared memory here to resolve. 
Also, since several autogluon pkgs installed the code fetching version was broken, so updated to get appropriate version number.

Additional tests failing are 
* sagemaker-studio-analytics-extension - this requires credentials. Need to decide whether to rewrite tests to not require creds (preferred) or add creds to codebuild
* pandas - https://github.com/aws/sagemaker-distribution/issues/110
* scipy - https://github.com/aws/sagemaker-distribution/issues/30
* sagemaker-python-sdk - see `ConnectionError: 400` for mocking sagemaker_session in tests/unit/sagemaker/monitor/test_model_monitoring.py::test_data_quality_monitor_update_failure . Will need more investigation if it continues to fail, but the other ~10000 tests pass



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
