### PR TITLE
feature: Add OpenSSL FIPS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ USER $MAMBA_USER
 RUN micromamba install sagemaker-inference --freeze-installed --yes --channel conda-forge --name base
 ```
 
+## FIPS
+
+As of sagemaker-distribution: v0.12+, v1.6+, and v2+, the images come with FIPS 140-2 validated openssl provider 
+available for use. You can enable the FIPS provider by running: 
+
+`export OPENSSL_CONF=/opt/conda/ssl/openssl-fips.cnf`
+
+For more info on the FIPS provider see: https://github.com/openssl/openssl/blob/master/README-FIPS.md
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/template/v0/Dockerfile
+++ b/template/v0/Dockerfile
@@ -10,6 +10,9 @@ ARG NB_USER="sagemaker-user"
 ARG NB_UID=1000
 ARG NB_GID=100
 
+# https://www.openssl.org/source/
+ARG FIPS_VALIDATED_SSL=3.0.8
+
 ENV SAGEMAKER_LOGGING_DIR="/var/log/sagemaker/"
 ENV STUDIO_LOGGING_DIR="/var/log/studio/"
 
@@ -96,6 +99,32 @@ RUN mkdir -p $SAGEMAKER_LOGGING_DIR && \
 USER $MAMBA_USER
 ENV PATH="/opt/conda/bin:/opt/conda/condabin:$PATH"
 WORKDIR "/home/${NB_USER}"
+
+# Install FIPS Provider for OpenSSL, on top of existing OpenSSL installation
+# v3.0.8 is latest FIPS validated provider, so this is the one we install
+# But we need to run tests against the installed version.
+# see https://github.com/openssl/openssl/blob/master/README-FIPS.md https://www.openssl.org/source/
+RUN INSTALLED_SSL=$(micromamba list | grep openssl | tr -s ' ' | cut -d ' ' -f 3 | head -n 1) && \
+    # download source code for installed, and FIPS validated openssl versions
+    curl -L https://www.openssl.org/source/openssl-$FIPS_VALIDATED_SSL.tar.gz > openssl-$FIPS_VALIDATED_SSL.tar.gz &&  \
+    curl -L https://www.openssl.org/source/openssl-$INSTALLED_SSL.tar.gz > openssl-$INSTALLED_SSL.tar.gz &&  \
+    tar -xf openssl-$FIPS_VALIDATED_SSL.tar.gz && tar -xf openssl-$INSTALLED_SSL.tar.gz && cd openssl-$FIPS_VALIDATED_SSL && \
+    # Configure both versions to enable FIPS and build
+    ./Configure enable-fips --prefix=/opt/conda --openssldir=/opt/conda/ssl && make && \
+    cd ../openssl-$INSTALLED_SSL && \
+    ./Configure enable-fips --prefix=/opt/conda --openssldir=/opt/conda/ssl && make && \
+    # Copy validated provider to installed version for testing
+    cp ../openssl-$FIPS_VALIDATED_SSL/providers/fips.so providers/. && \
+    cp ../openssl-$FIPS_VALIDATED_SSL/providers/fipsmodule.cnf providers/. && \
+    make tests && cd ../openssl-$FIPS_VALIDATED_SSL && \
+    # After tests pass, install FIPS provider and remove source code
+    make install_fips && cd .. && rm -rf ./openssl-*
+# Create new config file with fips-enabled. Then user can override OPENSSL_CONF to enable FIPS
+# e.g. export OPENSSL_CONF=/opt/conda/ssl/openssl-fips.cnf
+RUN cp /opt/conda/ssl/openssl.cnf /opt/conda/ssl/openssl-fips.cnf && \
+    sed -i "s:# .include fipsmodule.cnf:.include /opt/conda/ssl/fipsmodule.cnf:" /opt/conda/ssl/openssl-fips.cnf && \
+    sed -i 's:# fips = fips_sect:fips = fips_sect:' /opt/conda/ssl/openssl-fips.cnf
+ENV OPENSSL_MODULES=/opt/conda/lib64/ossl-modules/
 
 # Install Kerberos.
 # Make sure no dependency is added/updated

--- a/template/v1/Dockerfile
+++ b/template/v1/Dockerfile
@@ -12,6 +12,9 @@ ARG NB_USER="sagemaker-user"
 ARG NB_UID=1000
 ARG NB_GID=100
 
+# https://www.openssl.org/source/
+ARG FIPS_VALIDATED_SSL=3.0.8
+
 ENV SAGEMAKER_LOGGING_DIR="/var/log/sagemaker/"
 ENV STUDIO_LOGGING_DIR="/var/log/studio/"
 
@@ -106,6 +109,32 @@ RUN mkdir -p /var/run/supervisord && \
 USER $MAMBA_USER
 ENV PATH="/opt/conda/bin:/opt/conda/condabin:$PATH"
 WORKDIR "/home/${NB_USER}"
+
+# Install FIPS Provider for OpenSSL, on top of existing OpenSSL installation
+# v3.0.8 is latest FIPS validated provider, so this is the one we install
+# But we need to run tests against the installed version.
+# see https://github.com/openssl/openssl/blob/master/README-FIPS.md https://www.openssl.org/source/
+RUN INSTALLED_SSL=$(micromamba list | grep openssl | tr -s ' ' | cut -d ' ' -f 3 | head -n 1) && \
+    # download source code for installed, and FIPS validated openssl versions
+    curl -L https://www.openssl.org/source/openssl-$FIPS_VALIDATED_SSL.tar.gz > openssl-$FIPS_VALIDATED_SSL.tar.gz &&  \
+    curl -L https://www.openssl.org/source/openssl-$INSTALLED_SSL.tar.gz > openssl-$INSTALLED_SSL.tar.gz &&  \
+    tar -xf openssl-$FIPS_VALIDATED_SSL.tar.gz && tar -xf openssl-$INSTALLED_SSL.tar.gz && cd openssl-$FIPS_VALIDATED_SSL && \
+    # Configure both versions to enable FIPS and build
+    ./Configure enable-fips --prefix=/opt/conda --openssldir=/opt/conda/ssl && make && \
+    cd ../openssl-$INSTALLED_SSL && \
+    ./Configure enable-fips --prefix=/opt/conda --openssldir=/opt/conda/ssl && make && \
+    # Copy validated provider to installed version for testing
+    cp ../openssl-$FIPS_VALIDATED_SSL/providers/fips.so providers/. && \
+    cp ../openssl-$FIPS_VALIDATED_SSL/providers/fipsmodule.cnf providers/. && \
+    make tests && cd ../openssl-$FIPS_VALIDATED_SSL && \
+    # After tests pass, install FIPS provider and remove source code
+    make install_fips && cd .. && rm -rf ./openssl-*
+# Create new config file with fips-enabled. Then user can override OPENSSL_CONF to enable FIPS
+# e.g. export OPENSSL_CONF=/opt/conda/ssl/openssl-fips.cnf
+RUN cp /opt/conda/ssl/openssl.cnf /opt/conda/ssl/openssl-fips.cnf && \
+    sed -i "s:# .include fipsmodule.cnf:.include /opt/conda/ssl/fipsmodule.cnf:" /opt/conda/ssl/openssl-fips.cnf && \
+    sed -i 's:# fips = fips_sect:fips = fips_sect:' /opt/conda/ssl/openssl-fips.cnf
+ENV OPENSSL_MODULES=/opt/conda/lib64/ossl-modules/
 
 # Install Kerberos.
 # Make sure no dependency is added/updated


### PR DESCRIPTION
*Issue #, if available:*  https://github.com/aws/sagemaker-distribution/issues/161

*Description of changes:* 
Adding OpenSSL FIPS provider. We will install OpenSSL using conda-forge to ensure compatibility with all packages, however the latest FIPS-verified provider is from OpenSSL 3.0.8. Followed [these instructions](https://github.com/openssl/openssl/blob/master/README-FIPS.md#installing-the-fips-provider-and-using-it-with-the-latest-release) for installing FIPS-verified provider on top of existing OpenSSL installation, which involves fetching source code for both installed and verified versions, testing the verified providers against the installed version, then installing just the FIPS provider from 3.0.8. 

For testing, build new v0 and v1 image and ran following commands on cpu and gpu for both, with same outputs all around. This tests listing providers before and after enabling FIPS, and then trying a non-FIPS algorithm (md5) to make sure it works before enabling, and doesn't work after:
```
(base) sagemaker-user@37b559f52280:~$ openssl list -providers
Providers:
  default
    name: OpenSSL Default Provider
    version: 3.2.1
    status: active
(base) sagemaker-user@37b559f52280:~$ openssl md5 .profile
MD5(.profile)= f4e81ade7d6f9fb342541152d08e7a97
(base) sagemaker-user@37b559f52280:~$ export OPENSSL_CONF=/opt/conda/ssl/openssl-fips.cnf
(base) sagemaker-user@37b559f52280:~$ openssl list -providers
Providers:
  fips
    name: OpenSSL FIPS Provider
    version: 3.0.8
    status: active
(base) sagemaker-user@37b559f52280:~$ openssl md5 .profile
Error setting digest
40D758BC377F0000:error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:crypto/evp/evp_fetch.c:355:Global default library context, Algorithm (MD5 : 100), Properties ()
40D758BC377F0000:error:03000086:digital envelope routines:evp_md_init_internal:initialization error:crypto/evp/digest.c:272:
(base) sagemaker-user@37b559f52280:~$ openssl sha1 .profile
SHA1(.profile)= 2b9ee6d446f8f9ffccaab42b6df5649f749a9a07
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
