### PR TITLE
fix: Fix codebuild project name

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -97,5 +97,5 @@ jobs:
         env:
           CODEBUILD__sourceVersion: 'pr/${{ needs.open-pr.outputs.pr_id }}'
         with:
-          projectName: build-test-public-image
+          projectName: 'buildtestpublicimage1C7307A-9AzES2hf19lW'
 	  buildspec: '{"imageOverride": "aws/codebuild/standard:7.0"}'

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -98,4 +98,4 @@ jobs:
           CODEBUILD__sourceVersion: 'pr/${{ needs.open-pr.outputs.pr_id }}'
         with:
           projectName: 'buildtestpublicimage1C7307A-9AzES2hf19lW'
-	  buildspec: '{"imageOverride": "aws/codebuild/standard:7.0"}'
+          buildspec: '{"imageOverride": "aws/codebuild/standard:7.0"}'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* CDK created a unique name for testing CodeBuild when it was created. So, updating the name here to match.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
