### PR TITLE
fix: Fix version parsing for pre/post releases

### DIFF
--- a/src/dependency_upgrader.py
+++ b/src/dependency_upgrader.py
@@ -10,6 +10,11 @@ def _get_dependency_upper_bound_for_runtime_upgrade(dependency_name: str, lower_
     version_upgrade_strategy = 'semver' if metadata is None else metadata['version_upgrade_strategy']
 
     func = _version_upgrade_metadata[version_upgrade_strategy]['func']
+    # Version strings on conda-forge follow PEP standards rather than SemVer, which support
+    # version strings such as X.Y.Z.postN, X.Y.Z.preN. These cause errors in semver.Version.parse
+    # so we keep the first 3 entries as version string.
+    if lower_bound.count('.') > 2:
+        lower_bound = '.'.join(lower_bound.split('.')[:3])
     return func(lower_bound, runtime_upgrade_type)
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -23,6 +23,11 @@ def is_exists_dir_for_version(version: Version, file_name_to_verify_existence='D
 
 
 def get_semver(version_str) -> Version:
+    # Version strings on conda-forge follow PEP standards rather than SemVer, which support
+    # version strings such as X.Y.Z.postN, X.Y.Z.preN. These cause errors in semver.Version.parse
+    # so we keep the first 3 entries as version string.
+    if version_str.count('.') > 2:
+        version_str = '.'.join(version_str.split('.')[:3])
     version = Version.parse(version_str)
     if version.build is not None:
         raise Exception()

--- a/test/test_dependency_upgrader.py
+++ b/test/test_dependency_upgrader.py
@@ -43,3 +43,11 @@ def test_get_dependency_upper_bound_for_pythonesque():
     with pytest.raises(Exception):
         _get_dependency_upper_bound_for_pythonesque('1.2.5', 'prerelease')
 
+
+def test_get_dependency_upper_bound_for_post_pre_release():
+    assert _get_dependency_upper_bound_for_runtime_upgrade('python', '1.2.5.post1', _PATCH) == ',<1.3.0'
+    assert _get_dependency_upper_bound_for_runtime_upgrade('node', '1.2.5.post1', _PATCH) == ',<1.3.0'
+    assert _get_dependency_upper_bound_for_runtime_upgrade('python', '1.2.5.post1', _MINOR) == ',<1.3.0'
+    assert _get_dependency_upper_bound_for_runtime_upgrade('node', '1.2.5.post1', _MINOR) == ',<2.0.0'
+    assert _get_dependency_upper_bound_for_runtime_upgrade('python', '1.2.5.post1', _MAJOR) == ''
+    assert _get_dependency_upper_bound_for_runtime_upgrade('node', '1.2.5.post1', _MAJOR) == ''


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/sagemaker-distribution/issues/177

*Description of changes:* Semver fails with strings like 1.2.3.post1 which are supported by conda-forge, which has led to problems. If there are > 2 periods, we get first 3 entries only.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
