### PR TITLE
fix: Fix codebuild authentication

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -89,13 +89,14 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.START_CODEBUILD_ROLE }}
-          aws-region: us-west-2
+          aws-region: us-east-1
           # CodeBuild timeout of 8 hours
           role-duration-seconds: 3840
+          audience: https://sts.us-east-1.amazonaws.com
       - name: Run CodeBuild
         uses: dark-mechanicum/aws-codebuild@v1
         env:
           CODEBUILD__sourceVersion: 'pr/${{ needs.open-pr.outputs.pr_id }}'
         with:
-          projectName: 'buildtestpublicimage1C7307A-9AzES2hf19lW'
-          buildspec: '{"imageOverride": "aws/codebuild/standard:7.0"}'
+          projectName: ${{ secrets.CODEBUILD_JOB_NAME }}
+          buildspec: '{"imageOverride": "aws/codebuild/standard:7.0", "imagePullCredentialsTypeOverride": "CODEBUILD"}'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Codebuild seeing some issues due to token audience, found that changing audience in the workflow as well as OIDC provider on the backend resolves the issue. Also, move the projectName to secrets, and override imagePullCredentialsType due to issue introduced by CDK. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
