### PR TITLE
change: Push to ECR before running tests

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -174,15 +174,15 @@ def build_images(args):
                                                     args.force, args.skip_tests)
     generate_release_notes(target_version)
 
+    # Upload to ECR before running tests so that only the exact image which we tested goes to public
+    if args.target_ecr_repo is not None:
+        _push_images_upstream(image_versions, args.region)
+
     if not args.skip_tests:
         print(f'Will now run tests against: {image_ids}')
         _test_local_images(image_ids, args.target_patch_version)
     else:
         print('Will skip tests.')
-
-    # We only upload to ECR once all images are successfully built locally.
-    if args.target_ecr_repo is not None:
-        _push_images_upstream(image_versions, args.region)
 
 
 def _push_images_upstream(image_versions_to_push: list[dict[str, str]], region: str):

--- a/src/main.py
+++ b/src/main.py
@@ -175,6 +175,7 @@ def build_images(args):
     generate_release_notes(target_version)
 
     # Upload to ECR before running tests so that only the exact image which we tested goes to public
+    # TODO: Move after tests are stabilized
     if args.target_ecr_repo is not None:
         _push_images_upstream(image_versions, args.region)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Currently, if --target-ecr-repo is specified, and --skip-tests is _not_ specified, we would only push to ECR if all tests pass for both image variants. With the current state of our test suites, this doesn't happen. This means that we need to build an image and run tests, then push the image in a separate build (or do some local tag manipulation). This means, if we do two build commands, the image which is pushed could be different than the image which was tested.

In our current manual/automated build process, we run the tests and push to private, and separately push to public after the release PR is merged. In this case, we want to push to private the image which is tested, then be able to push to public the exact image which was tested. There currently isn't a stream where we would want a push to be blocked by tests failing. So, push to ECR repo prior to running tests, then use test results to decide whether to push that image to public.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
