### PR TITLE
fix: Fixes for automated testing

### DIFF
--- a/test/test_artifacts/v1/keras.test.Dockerfile
+++ b/test/test_artifacts/v1/keras.test.Dockerfile
@@ -8,7 +8,7 @@ RUN sudo apt-get update && sudo apt-get install -y git graphviz && \
     :
 
 # Some of the keras guides requires pydot and graphviz to be installed
-RUN micromamba install -y --freeze-installed conda-forge::pydot nvidia::cuda-nvcc
+RUN micromamba install -y --freeze-installed conda-forge::pydot "nvidia::cuda-nvcc>=11.8,<11.9"
 ENV XLA_FLAGS=--xla_gpu_cuda_data_dir=/opt/conda
 
 WORKDIR "keras-io/guides"
@@ -22,4 +22,3 @@ COPY --chown=$MAMBA_USER:$MAMBA_USER scripts/run_keras_tests.sh .
 RUN chmod +x run_keras_tests.sh
 # Run tests in run_keras_tests.sh
 CMD ["./run_keras_tests.sh"]
-

--- a/test/test_artifacts/v1/pytorch.examples.Dockerfile
+++ b/test/test_artifacts/v1/pytorch.examples.Dockerfile
@@ -2,10 +2,11 @@ ARG COSMOS_IMAGE
 FROM $COSMOS_IMAGE
 
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
-RUN sudo apt-get update && \
-    sudo apt-get install -y git && \
-    git clone --recursive https://github.com/pytorch/examples && \
-    :
+RUN git clone --recursive https://github.com/pytorch/examples
+
+# During automation some tests fails with `libcuda.so: cannot open shared object file: No such file or directory`
+# But libcuda.so.1 exists. Adding this resolves, but also adding `2>/dev/null` to ignore if not needed.
+RUN sudo ln -s /usr/lib/x86_64-linux-gnu/libcuda.so.1 /usr/lib/x86_64-linux-gnu/libcuda.so 2>/dev/null
 
 WORKDIR "examples"
 

--- a/test/test_artifacts/v1/scripts/run_autogluon_tests.sh
+++ b/test/test_artifacts/v1/scripts/run_autogluon_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-AUTOGLUON_VERSION=$(micromamba list | grep autogluon | tr -s ' ' | cut -d ' ' -f 3)
+AUTOGLUON_VERSION=$(micromamba list | grep autogluon | tr -s ' ' | head -n 1 | cut -d ' ' -f 3)
 git checkout tags/v$AUTOGLUON_VERSION
 
 # Run autogluon quick start as end-to-end check

--- a/test/test_artifacts/v1/sm-python-sdk.test.Dockerfile
+++ b/test/test_artifacts/v1/sm-python-sdk.test.Dockerfile
@@ -2,9 +2,8 @@ ARG COSMOS_IMAGE
 FROM $COSMOS_IMAGE
 
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
-RUN sudo apt-get update && sudo apt-get install -y git && \
-    git clone --recursive https://github.com/aws/sagemaker-python-sdk.git && \
-    :
+RUN git clone --recursive https://github.com/aws/sagemaker-python-sdk.git
+
 # Sagemaker Python SDK's unit tests requires AWS_DEFAULT_REGION to be set. So, using an arbitrary value of us-east-1
 ENV AWS_DEFAULT_REGION=us-east-1
 WORKDIR "sagemaker-python-sdk"

--- a/test/test_dockerfile_based_harness.py
+++ b/test/test_dockerfile_based_harness.py
@@ -130,7 +130,7 @@ def _validate_docker_images(dockerfile_path: str, required_packages: List[str],
 
     try:
         image, _ = _docker_client.images.build(path=test_artifacts_path,
-                                               dockerfile=dockerfile_path,
+                                               dockerfile=dockerfile_path, shmsize='256000000',
                                                tag=dockerfile_path.lower().replace('.', '-'),
                                                rm=True, buildargs={'COSMOS_IMAGE': docker_image_identifier})
     except BuildError as e:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Bunch of fixes to support testing on codebuild. Fixes failures for:
* keras - failed with cuda errors due to installing incompatible cuda-nvcc. Adding version constraints fixes this.
* pytorch - failed with `libcuda.so: cannot open shared object file: No such file or directory`. Adding a link between libcuda.so.1 to libcuda.so resolves. This is also done in codebuild, but must not carry over into the test dockerfile
* autogluon - saw errors that shmsize was not sufficient. Increasing from default 64mb to 256mb resolves. Also, since there are ~5 pkgs containing autogluon, the version fetching line wasn't working. Updated to pull version correctly.

Additional failures
* sm-python-sdk - saw failures for 3 tests. 2 related to not having docker access, and 1 related to not having credentials. Will revisit and skip, and look into if we can remove some of the currently skipped tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
