### PR TITLE
fix: Improvements for testing

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -91,7 +91,7 @@ jobs:
           role-to-assume: ${{ secrets.START_CODEBUILD_ROLE }}
           aws-region: us-east-1
           # CodeBuild timeout of 8 hours
-          role-duration-seconds: 3840
+          role-duration-seconds: 28800
           audience: https://sts.us-east-1.amazonaws.com
       - name: Run CodeBuild
         uses: dark-mechanicum/aws-codebuild@v1

--- a/src/main.py
+++ b/src/main.py
@@ -199,11 +199,16 @@ def _push_images_upstream(image_versions_to_push: list[dict[str, str]], region: 
 
 def _test_local_images(image_ids_to_test: list[str], target_version: str):
     assert len(image_ids_to_test) == len(_image_generator_configs)
+    exit_codes = []
+    image_ids = []
     for (image_id, config) in zip(image_ids_to_test, _image_generator_configs):
-        exit_code = pytest.main(['-n', 'auto', '-m', config['image_type'], '--local-image-version',
+        exit_code = pytest.main(['-n', '2', '-m', config['image_type'], '--local-image-version',
                                  target_version, *config['pytest_flags']])
+        if exit_code != 0:
+            exit_codes.append(exit_code)
+            image_ids.append(image_id)
 
-        assert exit_code == 0, f'Tests failed with exit code: {exit_code} against: {image_id}'
+    assert len(exit_codes) == 0, f'Tests failed with exit codes: {exit_codes} against: {image_ids}'
 
     print(f'Tests ran successfully against: {image_ids_to_test}')
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently if tests fail against one variant, e.g. gpu, tests won't run against others. This change updates to run on all variants and return exit codes at the end. 
Also update to use 2 workers as we see resource issues with more, and update codebuild role timeout to actually be 8 hours.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
