### PR TITLE
fix: Increase shm_size for tests

### DIFF
--- a/test/test_dockerfile_based_harness.py
+++ b/test/test_dockerfile_based_harness.py
@@ -130,7 +130,7 @@ def _validate_docker_images(dockerfile_path: str, required_packages: List[str],
 
     try:
         image, _ = _docker_client.images.build(path=test_artifacts_path,
-                                               dockerfile=dockerfile_path, shmsize='256000000',
+                                               dockerfile=dockerfile_path, shmsize='512000000',
                                                tag=dockerfile_path.lower().replace('.', '-'),
                                                rm=True, buildargs={'SAGEMAKER_DISTRIBUTION_IMAGE': docker_image_identifier})
     except BuildError as e:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Still seeing occasional errors with autogluon test `ERROR: Unexpected bus error encountered in worker. This might be caused by insufficient shared memory (shm).` ([e.g.](https://cosmosrelease-githubcodebuildlogssar-1u1-buildlogs-io1ptro4snwc.s3.amazonaws.com/2d21d251-af85-4cd3-a353-b232ae56ed5b/build.log?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIA2GLMOUUQZ4MZZVQR%2F20240325%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240325T155133Z&X-Amz-Expires=600&X-Amz-SignedHeaders=host&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHgaCXVzLWVhc3QtMSJGMEQCIAvowSE%2BIy8uxDaW3e4HnHRe4VI03qwqFr2HXBlfXFdqAiBgfFKKgQsm0AK7lTBXmgivl780yb8u9PF9NNZfMvyk8CrcAwiR%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F8BEAAaDDcwMDg0Mzk5MjM1MyIMNB6LKSI5k0sUa7jXKrAD%2F7%2Fs5tZvupE%2BwEfHqs5UNXG6RP4pPWfmCLSuubS8sH%2BTOOXpjd%2Bl1whAYDZMQrWOFt06uoCx4pnyP0a6%2BO%2FLVXKaJ7iqX1f9tQ7SF3U38qY1dtvdhmTJQFXdFvP%2BN3XL6fkdakSB5hwiO6HIRgyc5ZiPBRrQokE0faU3eqYzkXTm3BL9g6%2FWZqWDNVP3zip8sFdRtQ0hLCgl3jnYMoeapuPqCIiPOCFbSpm89dosGKcqHeorhORk2g1Mr6tZIFLgpGaH6Gpy4yH0gA8aXYy93udD1wDyWwOjRY2ULooRgY%2F%2FW7Y2%2B4r9hCADI3OddHrQQLknrEgs6JIgAaGLIkKqxXnCQABCe08ThYArp%2Bwx9%2Bj5KS1gflxvy%2B%2BPR5rwBEMTwbSQZtuMUIUmcpRvm0mKRkNazLmM6za8DehuwgpQeCx4aHzxV5L5YVQmtBZBgzke8kTf7NQzytgKqAeo4rm2J1i%2BZUh6v8qY8Rc2xBFj2OYX40yxOhhzZ46jeUyXdBsPWS407mTCRyjrMcmnJuooNk91%2BkjfwyQzMZqkFyfnbXrqaJH6i7uJSOR8VTu7ZhPJMIS7hrAGOp8BlZEpY%2Fo7jpisbk%2FriVgxDdO7k50PAHJ5aX%2BhD%2FSJaoOlfRz49yjXfzZK61Vg4X%2FvZzlbAs4P43FNeUYs8kPOHL%2FHVbfrZWhbI9XCTx2AWxhk3uovjMMa9Izr7sBl2PLyLAfo6ehgAvLn53PvmvEghh7v4kYTd5cydC9wMp1MryTmpBNHHwp6vat5WWGQ7XAljVMGmuYFX%2BeUzmaxcfVN&X-Amz-Signature=69bb82eefbf6968ebf832407e4f6a72f9f8e160d67e4591162f1634759af6c96)) Bumping the shm_size from 256 MB to 512 MB, it still works and should reduce that error.  Tested in personal account.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
