### PR TITLE
Add sql-language-server config for LanguageServerManager

### DIFF
--- a/template/v1/dirs/etc/jupyter/jupyter_server_config.py
+++ b/template/v1/dirs/etc/jupyter/jupyter_server_config.py
@@ -14,3 +14,16 @@ c.FileContentsManager.always_delete_dir = True
 # Enable `allow_hidden` by default, so hidden files are accessible via Jupyter server
 # Related documentation: https://jupyterlab.readthedocs.io/en/stable/user/files.html#displaying-hidden-files
 c.ContentsManager.allow_hidden = True
+
+# This will set the LanguageServerManager.extra_node_roots setting if amazon_sagemaker_sql_editor exists in the
+# environment. Ignore otherwise, don't fail the JL server start
+# Related documentation: https://jupyterlab-lsp.readthedocs.io/en/v3.4.0/Configuring.html
+try:
+    import os
+    module = __import__("amazon_sagemaker_sql_editor")
+    module_location = os.path.dirname(module.__file__)
+    c.LanguageServerManager.extra_node_roots = [
+        f'{module_location}/sql_language_server'
+    ]
+except:
+    pass

--- a/template/v1/dirs/etc/jupyter/jupyter_server_config.py
+++ b/template/v1/dirs/etc/jupyter/jupyter_server_config.py
@@ -23,7 +23,7 @@ try:
     module = __import__("amazon_sagemaker_sql_editor")
     module_location = os.path.dirname(module.__file__)
     c.LanguageServerManager.extra_node_roots = [
-        f'{module_location}/sql_language_server'
+        f'{module_location}/sql-language-server'
     ]
 except:
     pass


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Set the LanguageServerManager.extra_node_roots setting if amazon_sagemaker_sql_editor exists in the environment. Ignore otherwise, don't fail the JL server start.
Related documentation: https://jupyterlab-lsp.readthedocs.io/en/v3.4.0/Configuring.html

1. The new version of `amazon-sagemaker-sql-editor` is packaging `sql-language-server` in it at the path {module-root}/sql-language-server.
2. In this change we are telling LanguageServerManager to look into {module-root}/sql-language-server (if it is found, silently ignore error otherwise) via a jupyter config. This config tells where would LanguageServerManager look for servers and is isolated to the LSP feature.

Testing:
1. Created a custom image with the following Dockerfile
```
FROM public.ecr.aws/sagemaker/sagemaker-distribution:latest-cpu
ARG NB_USER="sagemaker-user"
ARG NB_UID=1000
ARG NB_GID=100

ENV MAMBA_USER=$NB_USER

USER root

RUN apt-get update
RUN micromamba install sagemaker-inference --freeze-installed --yes --channel conda-forge --name base
RUN micromamba install amazon-sagemaker-sql-magic --yes --channel conda-forge --name base
COPY ./setupExt.txt setupExt.txt
RUN cat setupExt.txt >> /etc/jupyter/jupyter_server_config.py # file content below

USER $MAMBA_USER

COPY --chown=$NB_USER ./amazon_sagemaker_sql_editor-0.1.3.tar.gz amazon_sagemaker_sql_editor-0.1.3.tar.gz
RUN pip install amazon_sagemaker_sql_editor-0.1.3.tar.gz # latest version is not yet in conda, we are working on it.

ENTRYPOINT ["jupyter-lab"]
CMD ["--ServerApp.ip=0.0.0.0", "--ServerApp.port=8888", "--ServerApp.allow_origin=*", "--ServerApp.token=''", "--ServerApp.base_url=/jupyterlab/default"]
```

setupExt.txt
```
try:
    import os
    module = __import__("amazon_sagemaker_sql_editor")
    module_location = os.path.dirname(module.__file__)
    c.LanguageServerManager.extra_node_roots = [
        f'{module_location}/sql-language-server'
    ]
except:
    pass
```

2. Create a sagemaker app with this image and tested autocomplete is working without any additional npm installations.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
