### PR TITLE
Add git-remote-codecommit to SMD

### DIFF
--- a/build_artifacts/v2/v2.0/v2.0.0/v2.0.0-beta/cpu.additional_packages_env.in
+++ b/build_artifacts/v2/v2.0/v2.0.0/v2.0.0-beta/cpu.additional_packages_env.in
@@ -2,3 +2,4 @@
 /tmp/local-packages::maxdome_jupyter_server_extension[version='>=0.1.0']
 /tmp/local-packages::maxdome_jupyter_session_manager[version='>=0.1.0']
 /tmp/local-packages::maxdome_toolkit_cli[version='>=0.1.0']
+conda-forge::git-remote-codecommit[version='>=0.0.0']

--- a/build_artifacts/v2/v2.0/v2.0.0/v2.0.0-beta/gpu.additional_packages_env.in
+++ b/build_artifacts/v2/v2.0/v2.0.0/v2.0.0-beta/gpu.additional_packages_env.in
@@ -2,3 +2,4 @@
 /tmp/local-packages::maxdome_jupyter_server_extension[version='>=0.1.0']
 /tmp/local-packages::maxdome_jupyter_session_manager[version='>=0.1.0']
 /tmp/local-packages::maxdome_toolkit_cli[version='>=0.1.0']
+conda-forge::git-remote-codecommit[version='>=0.0.0']

--- a/test/test_artifacts/v2/git-remote-codecommit.test.Dockerfile
+++ b/test/test_artifacts/v2/git-remote-codecommit.test.Dockerfile
@@ -1,0 +1,14 @@
+ARG COSMOS_IMAGE
+FROM $COSMOS_IMAGE
+
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+RUN micromamba install -y --freeze-installed -c conda-forge pytest
+
+RUN sudo apt-get update && \
+    sudo apt-get install -y git && \
+    git clone --recursive  https://github.com/aws/git-remote-codecommit.git && \
+    :
+WORKDIR "git-remote-codecommit"
+COPY --chown=$MAMBA_USER:$MAMBA_USER scripts/run_git_remote_codecommit_test.sh .
+RUN chmod +x run_git_remote_codecommit_test.sh
+CMD ["./run_git_remote_codecommit_test.sh"]

--- a/test/test_artifacts/v2/scripts/run_git_remote_codecommit_test.sh
+++ b/test/test_artifacts/v2/scripts/run_git_remote_codecommit_test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# We need to checkout the version of git-remote-codecommit that is installed in the mamba environment.
+
+version=$(micromamba list | grep git-remote-codecommit | tr -s ' ' | cut -d ' ' -f 3)
+# Checkout the corresponding version
+git checkout tags/$version
+
+# Run the tests
+pytest  test/git_url_test.py test/main_test.py || exit $?

--- a/test/test_dockerfile_based_harness.py
+++ b/test/test_dockerfile_based_harness.py
@@ -41,6 +41,7 @@ _docker_client = docker.from_env()
     ("maxdome_jupyter_server_extension.test.Dockerfile", ['maxdome_jupyter_server_extension']),
     ("maxdome_jupyter_session_manager.test.Dockerfile", ['maxdome_jupyter_session_manager']),
     ("maxdome_toolkit_cli.test.Dockerfile",['maxdome_toolkit_cli']),
+    ("git-remote-codecommit.test.Dockerfile",['git-remote-codecommit']),
     ("serve.test.Dockerfile", ['serve-langchain'])])
 def test_dockerfiles_for_cpu(dockerfile_path: str, required_packages: List[str],
                              local_image_version: str, use_gpu: bool):
@@ -74,6 +75,7 @@ def test_dockerfiles_for_cpu(dockerfile_path: str, required_packages: List[str],
     ("maxdome_jupyter_server_extension.test.Dockerfile", ['maxdome_jupyter_server_extension']),
     ("maxdome_jupyter_session_manager.test.Dockerfile", ['maxdome_jupyter_session_manager']),
     ("maxdome_toolkit_cli.test.Dockerfile",['maxdome_toolkit_cli']),
+    ("git-remote-codecommit.test.Dockerfile",['git-remote-codecommit']),
     ("serve.test.Dockerfile", ['serve-langchain'])])
 def test_dockerfiles_for_gpu(dockerfile_path: str, required_packages: List[str],
                              local_image_version: str, use_gpu: bool):


### PR DESCRIPTION
Test:
- Build image locally and goes into the docker container and verified installation via conda list
- Added test case and verified by: pytest -m gpu --local-image-version 2.0.0-beta -k  git-remote-codecommit pytest -m cpu --local-image-version 2.0.0-beta -k  git-remote-codecommit

*Issue #, if available:* N/A

*Description of changes:*
Add git-remote-codecommit to SMD

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
