### PR TITLE
create dir to store user data files

### DIFF
--- a/template/v1/Dockerfile
+++ b/template/v1/Dockerfile
@@ -49,9 +49,9 @@ RUN echo "source /usr/local/bin/_activate_current_env.sh" | tee --append /etc/pr
 RUN mkdir -p /opt/amazon/sagemaker/sagemaker-code-editor-server-data /opt/amazon/sagemaker/sagemaker-code-editor-user-data \
     && chown $MAMBA_USER:$MAMBA_USER /opt/amazon/sagemaker/sagemaker-code-editor-server-data /opt/amazon/sagemaker/sagemaker-code-editor-user-data
 
-# SQLEditor - create dir to store user data files
-RUN mkdir -p /opt/amazon/sagemaker/sagemaker-sql-experience-user-data \
-    && chown $MAMBA_USER:$MAMBA_USER /opt/amazon/sagemaker/sagemaker-sql-experience-user-data
+# create dir to store user data files
+RUN mkdir -p /opt/amazon/sagemaker/user-data \
+    && chown $MAMBA_USER:$MAMBA_USER /opt/amazon/sagemaker/user-data
 
 
 # Merge in OS directory tree contents.

--- a/template/v1/Dockerfile
+++ b/template/v1/Dockerfile
@@ -49,6 +49,11 @@ RUN echo "source /usr/local/bin/_activate_current_env.sh" | tee --append /etc/pr
 RUN mkdir -p /opt/amazon/sagemaker/sagemaker-code-editor-server-data /opt/amazon/sagemaker/sagemaker-code-editor-user-data \
     && chown $MAMBA_USER:$MAMBA_USER /opt/amazon/sagemaker/sagemaker-code-editor-server-data /opt/amazon/sagemaker/sagemaker-code-editor-user-data
 
+# SQLEditor - create dir to store autocomplete schema files
+RUN mkdir -p /opt/amazon/sagemaker/sql-autocomplete-schema \
+    && chown $MAMBA_USER:$MAMBA_USER /opt/amazon/sagemaker/sql-autocomplete-schema
+
+
 # Merge in OS directory tree contents.
 RUN mkdir -p ${DIRECTORY_TREE_STAGE_DIR}
 COPY dirs/ ${DIRECTORY_TREE_STAGE_DIR}/
@@ -180,3 +185,4 @@ RUN SYSTEM_PYTHON_PATH=$(python3 -c "from __future__ import print_function;impor
     sed -i 's="PySpark"="SparkMagic PySpark"=g'  /opt/conda/share/jupyter/kernels/pysparkkernel/kernel.json
 
 ENV SHELL=/bin/bash
+

--- a/template/v1/Dockerfile
+++ b/template/v1/Dockerfile
@@ -49,9 +49,9 @@ RUN echo "source /usr/local/bin/_activate_current_env.sh" | tee --append /etc/pr
 RUN mkdir -p /opt/amazon/sagemaker/sagemaker-code-editor-server-data /opt/amazon/sagemaker/sagemaker-code-editor-user-data \
     && chown $MAMBA_USER:$MAMBA_USER /opt/amazon/sagemaker/sagemaker-code-editor-server-data /opt/amazon/sagemaker/sagemaker-code-editor-user-data
 
-# SQLEditor - create dir to store autocomplete schema files
-RUN mkdir -p /opt/amazon/sagemaker/sql-autocomplete-schema \
-    && chown $MAMBA_USER:$MAMBA_USER /opt/amazon/sagemaker/sql-autocomplete-schema
+# SQLEditor - create dir to store user data files
+RUN mkdir -p /opt/amazon/sagemaker/sagemaker-sql-experience-user-data \
+    && chown $MAMBA_USER:$MAMBA_USER /opt/amazon/sagemaker/sagemaker-sql-experience-user-data
 
 
 # Merge in OS directory tree contents.


### PR DESCRIPTION
*Issue #, if available:*
`amazon_sagemaker_sql_editor` extension creates and stores cache files for autocompletion capability under `/home/sagemaker` directory. To avoid exposing customers to such internal working files, we create `/opt/amazon/sagemaker/user-data` which extensions can use to store files.


*Description of changes:*
Create a dir `/opt/amazon/sagemaker/user-data` in which `amazon_sagemaker_sql_editor` extension can create and store files for use.

*Testing*
1. Created a custom image with the following Dockerfile
```
FROM public.ecr.aws/sagemaker/sagemaker-distribution:latest-cpu
ARG NB_USER="sagemaker-user"
ARG NB_UID=1000
ARG NB_GID=100

ENV MAMBA_USER=$NB_USER

USER root

RUN mkdir -p /opt/amazon/sagemaker/sagemaker-sql-experience-user-data \
    && chown $MAMBA_USER:$MAMBA_USER /opt/amazon/sagemaker/sagemaker-sql-experience-user-data

USER $MAMBA_USER

ENTRYPOINT ["jupyter-lab"]
CMD ["--ServerApp.ip=0.0.0.0", "--ServerApp.port=8888", "--ServerApp.allow_origin=*", "--ServerApp.token=''", "--ServerApp.base_url=/jupyterlab/default"]
```

2. Create a Sagemaker app using the above Dockerfile and checked if directories are created with appropriate permissions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
