### PR TITLE
Only remove kernel when installed

### DIFF
--- a/build_artifacts/v2/v2.0/v2.0.0/v2.0.0-beta/dirs/etc/maxdome/kernels/kernel_launchers/glue_kernel_launcher.sh
+++ b/build_artifacts/v2/v2.0/v2.0.0/v2.0.0-beta/dirs/etc/maxdome/kernels/kernel_launchers/glue_kernel_launcher.sh
@@ -29,7 +29,6 @@ kernel_type=$2
 connection_file=$4
 
 maxdome_connection=`maxdome get connection --name $MAXDOME_CONNECTION_NAME --authorization-mode PROJECT --with-secret`
-export glue_role_arn=$(echo "$maxdome_connection" | jq .environmentUserRoleArn -r)
 export AWS_REGION=$(echo "$maxdome_connection" | jq .location.awsRegion -r)
 
 export_if_key_exists "$maxdome_connection" "sparkGlueProperties.glueConnection.Name" "glue_connections" 

--- a/build_artifacts/v2/v2.0/v2.0.0/v2.0.0-beta/dirs/usr/local/bin/start-maxdome-jupyter-server
+++ b/build_artifacts/v2/v2.0/v2.0.0/v2.0.0-beta/dirs/usr/local/bin/start-maxdome-jupyter-server
@@ -14,8 +14,13 @@ aws configure set credential_process "/etc/maxdome/get_credential.sh" --profile 
 mkdir -p /opt/conda/share/jupyter/lab/settings
 cp /etc/maxdome/page_config.json /opt/conda/share/jupyter/lab/settings
 
-jupyter-kernelspec remove -f -y pysparkkernel
-jupyter-kernelspec remove -f -y sparkkernel
+if [[ $(jupyter kernelspec list | grep pysparkkernel) ]]; then
+  jupyter-kernelspec remove -f -y pysparkkernel
+fi
+
+if [[ $(jupyter kernelspec list | grep sparkkernel) ]]; then
+  jupyter-kernelspec remove -f -y sparkkernel
+fi
 
 jupyter lab --ip 0.0.0.0 --port 8888 \
   --ServerApp.token='' \

--- a/template/v2/dirs/etc/maxdome/kernels/kernel_launchers/glue_kernel_launcher.sh
+++ b/template/v2/dirs/etc/maxdome/kernels/kernel_launchers/glue_kernel_launcher.sh
@@ -29,7 +29,6 @@ kernel_type=$2
 connection_file=$4
 
 maxdome_connection=`maxdome get connection --name $MAXDOME_CONNECTION_NAME --authorization-mode PROJECT --with-secret`
-export glue_role_arn=$(echo "$maxdome_connection" | jq .environmentUserRoleArn -r)
 export AWS_REGION=$(echo "$maxdome_connection" | jq .location.awsRegion -r)
 
 export_if_key_exists "$maxdome_connection" "sparkGlueProperties.glueConnection.Name" "glue_connections"

--- a/template/v2/dirs/usr/local/bin/start-maxdome-jupyter-server
+++ b/template/v2/dirs/usr/local/bin/start-maxdome-jupyter-server
@@ -14,8 +14,13 @@ aws configure set credential_process "/etc/maxdome/get_credential.sh" --profile 
 mkdir -p /opt/conda/share/jupyter/lab/settings
 cp /etc/maxdome/page_config.json /opt/conda/share/jupyter/lab/settings
 
-jupyter-kernelspec remove -f -y pysparkkernel
-jupyter-kernelspec remove -f -y sparkkernel
+if [[ $(jupyter kernelspec list | grep pysparkkernel) ]]; then
+  jupyter-kernelspec remove -f -y pysparkkernel
+fi
+
+if [[ $(jupyter kernelspec list | grep sparkkernel) ]]; then
+  jupyter-kernelspec remove -f -y sparkkernel
+fi
 
 jupyter lab --ip 0.0.0.0 --port 8888 \
   --ServerApp.token='' \


### PR DESCRIPTION
During tests we noticed there will be error in restarting jupyter, because the script will error out as the kernel is already removed.

In this change, we will only remove the kernel when it is present.

We also removed glue_role_arn in kernel launcher script for glue.

Test:
Verify JupyterLab will auto restart when it is killed

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
