### PR TITLE
feature: Add versioning support for images with prerelease identifiers

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -79,12 +79,12 @@ def _create_new_version_artifacts(args):
         raise Exception()
 
     base_patch_version = get_semver(args.base_patch_version)
-    if base_patch_version.prerelease:
-        # We don't support creating new patch/major/minor versions from a prerelease version
-        # Re-run the build command for the prerelease version again to pick the latest versions
-        # of the marquee packages
+    if base_patch_version.prerelease and args.pre_release_identifier:
+        # We support creating new patch/major/minor versions from a pre-release version.
+        # But We don't support passing the pre_release_identifier parameter while creating a new
+        # patch/major/minor versions from the pre-release version.
         raise Exception()
-    next_version = getattr(base_patch_version, runtime_version_upgrade_func)()
+    next_version = _get_next_version(base_patch_version, runtime_version_upgrade_func)
 
     if args.pre_release_identifier:
         next_version = next_version.replace(prerelease=args.pre_release_identifier)
@@ -291,32 +291,41 @@ def _build_local_images(
     return generated_image_ids, generated_image_versions
 
 
+def _get_next_version(current_version: Version, upgrade_func: str) -> Version:
+    next_version = getattr(current_version, upgrade_func)()
+    if current_version.prerelease:
+        # Semver Ignores prerelease identifier when we do bump_{patch/minor/major}
+        next_version = next_version.replace(prerelease=current_version.prerelease)
+    return next_version
+
+
 # At some point of time, let's say some patch versions exist for both 2.6 and 2.7, and we create new patch
 # versions for both of them. Now, for the new 2.6.x, we can tag it as '2.6.x-cpu' and '2.6-cpu' but NOT '2-cpu' because
 # there is a more recent version (i.e. 2.7.x) that should be considered '2-cpu'. So, given a patch version, the
 # following function returns a list of versions for which the current patch version is latest for.
+# For versions with pre-release identifier, this method will return the appropriate tags
+# Example: For an version 2.0.0-beta, this method will return [2.0.0-beta, 2.0-beta, 2-beta,
+# latest-beta]
 def _get_version_tags(target_version: Version, env_out_file_name: str) -> list[str]:
     # First, add '2.6.x' as is.
     res = [str(target_version)]
-    # If this is a pre-release version, then don't add additional tags
-    if target_version.prerelease:
-        return res
+    prerelease_version_suffix = f"-{target_version.prerelease}" if target_version.prerelease else ""
 
     # If we were to add '2.6', check if '2.6.(x+1)' is present.
-    if not is_exists_dir_for_version(target_version.bump_patch(), env_out_file_name):
-        res.append(f"{target_version.major}.{target_version.minor}")
+    if not is_exists_dir_for_version(_get_next_version(target_version, "bump_patch"), env_out_file_name):
+        res.append(f"{target_version.major}.{target_version.minor}{prerelease_version_suffix}")
     else:
         return res
 
     # If we were to add '2', check if '2.7' is present.
-    if not is_exists_dir_for_version(target_version.bump_minor(), env_out_file_name):
-        res.append(str(target_version.major))
+    if not is_exists_dir_for_version(_get_next_version(target_version, "bump_minor"), env_out_file_name):
+        res.append(f"{target_version.major}{prerelease_version_suffix}")
     else:
         return res
 
     # If we were to add 'latest', check if '3.0.0' is present.
-    if not is_exists_dir_for_version(target_version.bump_major(), env_out_file_name):
-        res.append("latest")
+    if not is_exists_dir_for_version(_get_next_version(target_version, "bump_major"), env_out_file_name):
+        res.append(f"latest{prerelease_version_suffix}")
 
     return res
 


### PR DESCRIPTION
*Issue #, if available:*N/A

*Description of changes:*  Add versioning support for images with prerelease identifiers

Motivation:
* Currently we don't allow creating new {major/minor/patch} versions from a prerelease version.

What is changing:
Current behavior: if you invoke create-{major/minor/patch}-version-artifacts for a prerelease version (like 1.0.0-beta) you will get an exception.

New behavior: These invocations will succeed and it will create 3.0.0-beta/2.1.0-beta/2.0.1-beta respectively.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
