### PR TITLE
change: Disable scheduled releases

### DIFF
--- a/.github/workflows/monthly-minor-release.yml
+++ b/.github/workflows/monthly-minor-release.yml
@@ -1,8 +1,8 @@
 name: Generate monthly minor release(s)
 on:
   # Run first day of the month at 8AM PST / 9AM PDT
-  schedule:
-    - cron: '0 16 1 * *'
+  #schedule:
+  #  - cron: '0 16 1 * *'
 jobs:
   generate-version-matrix:
     name: Generate version matrix

--- a/.github/workflows/weekly-patch-release.yml
+++ b/.github/workflows/weekly-patch-release.yml
@@ -2,8 +2,8 @@ name: Generate weekly patch release(s)
 on:
   # Run every Monday at 6AM PST / 7AM PDT
   # Run before monthly, so we don't immediately patch a new minor version
-  schedule:
-    - cron: '0 14 * * MON'
+  #schedule:
+  #  - cron: '0 14 * * MON'
 jobs:
   generate-version-matrix:
     name: Generate-matrix


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Disabling scheduled releases for now; creating a lot of noise/infra stress for releases which we end up restarting anyways. Will re-enable once E2E release cadence has stabilized


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
