### PR TITLE
Make amazon q default language model

### DIFF
--- a/template/v1/dirs/etc/jupyter/jupyter_server_config.py
+++ b/template/v1/dirs/etc/jupyter/jupyter_server_config.py
@@ -24,5 +24,6 @@ try:
     module = __import__("amazon_sagemaker_sql_editor")
     module_location = os.path.dirname(module.__file__)
     c.LanguageServerManager.extra_node_roots = [f"{module_location}/sql-language-server"]
+    c.AiExtension.default_language_model = "amazon-q:q-developer"
 except:
     pass


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Make amazon q default language model for JupyterAI

Take a look at JupyterAI [docs](https://jupyter-ai.readthedocs.io/en/latest/users/index.html#configuration) about configurations for more info


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
