### PR TITLE
fix: Force script to exit when encountering failure

### DIFF
--- a/test/test_artifacts/v2/scripts/run_mlflow_tests.sh
+++ b/test/test_artifacts/v2/scripts/run_mlflow_tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Run examples for keras, pytorch, sklearn, tensorflow
 cd examples
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix an issue where the mlflow feature test script could potentially exit with no error even when a test fails.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
