### PR TITLE
feature: Add sagemaker-mlflow package

### DIFF
--- a/build_artifacts/v2/v2.0/v2.0.0/cpu.additional_packages_env.in
+++ b/build_artifacts/v2/v2.0/v2.0.0/cpu.additional_packages_env.in
@@ -1,2 +1,3 @@
 #Add any additional packages here
-conda-forge::mlflow[version='>=2.13.0,<3.0']
+conda-forge::mlflow[version='>=2.13.2,<3.0']
+conda-forge::sagemaker-mlflow[version='>=0.1.0,<1.0']

--- a/build_artifacts/v2/v2.0/v2.0.0/gpu.additional_packages_env.in
+++ b/build_artifacts/v2/v2.0/v2.0.0/gpu.additional_packages_env.in
@@ -1,2 +1,3 @@
 #Add any additional packages here
 conda-forge::mlflow[version='>=2.13.2,<3.0']
+conda-forge::sagemaker-mlflow[version='>=0.1.0,<1.0']

--- a/test/test_artifacts/v2/sagemaker-mlflow.test.Dockerfile
+++ b/test/test_artifacts/v2/sagemaker-mlflow.test.Dockerfile
@@ -1,0 +1,19 @@
+ARG SAGEMAKER_DISTRIBUTION_IMAGE
+FROM $SAGEMAKER_DISTRIBUTION_IMAGE
+
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+
+RUN python -c "import sagemaker_mlflow"
+
+RUN sudo apt-get update && sudo apt-get install -y git && \
+    git clone --recursive https://github.com/aws/sagemaker-mlflow.git && \
+    :
+
+# For running sagemaker-mlflow tests, we need pytest
+RUN micromamba install -y --freeze-installed -c conda-forge pytest
+
+WORKDIR "sagemaker-mlflow/"
+COPY --chown=$MAMBA_USER:$MAMBA_USER scripts/run_sagemaker_mlflow_tests.sh .
+RUN chmod +x run_sagemaker_mlflow_tests.sh
+# Run tests in run_matplotlib_tests.sh
+CMD ["./run_sagemaker_mlflow_tests.sh"]

--- a/test/test_artifacts/v2/scripts/run_mlflow_tests.sh
+++ b/test/test_artifacts/v2/scripts/run_mlflow_tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Run examples for keras, pytorch, sklearn, tensorflow
 cd examples
 

--- a/test/test_artifacts/v2/scripts/run_sagemaker_mlflow_tests.sh
+++ b/test/test_artifacts/v2/scripts/run_sagemaker_mlflow_tests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+pytest -s -rA -vv test/unit

--- a/test/test_dockerfile_based_harness.py
+++ b/test/test_dockerfile_based_harness.py
@@ -85,6 +85,7 @@ def test_dockerfiles_for_cpu(
         ("serve.test.Dockerfile", ["serve-langchain"]),
         ("langchain-aws.test.Dockerfile", ["langchain-aws"]),
         ("mlflow.test.Dockerfile", ["mlflow"]),
+        ("sagemaker-mlflow.test.Dockerfile", ["sagemaker-mlflow"]),
     ],
 )
 def test_dockerfiles_for_gpu(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add the sagemaker-mlflow package from conda-forge

*Test results:*
```
python -m pytest -n auto -m cpu -vv -rs -k "sagemaker-mlflow" --local-image-version $VERSION                                                                                    ──(Thu,Jun20)─┘
============================================================================================================== test session starts ==============================================================================================================
platform linux -- Python 3.12.3, pytest-8.2.2, pluggy-1.5.0 -- /home/saimidu/miniconda3/envs/sagemaker-distribution/bin/python
cachedir: .pytest_cache
rootdir: /local/home/saimidu/sagemaker-distribution
configfile: pytest.ini
plugins: xdist-3.6.1, mock-3.14.0
8 workers [1 item]
scheduling tests via LoadScheduling

test/test_dockerfile_based_harness.py::test_dockerfiles_for_cpu[sagemaker-mlflow.test.Dockerfile-required_packages28]
[gw0] [100%] PASSED test/test_dockerfile_based_harness.py::test_dockerfiles_for_cpu[sagemaker-mlflow.test.Dockerfile-required_packages28]

=============================================================================================================== warnings summary ================================================================================================================
../../../../home/saimidu/miniconda3/envs/sagemaker-distribution/lib/python3.12/site-packages/boltons/timeutils.py:426
../../../../home/saimidu/miniconda3/envs/sagemaker-distribution/lib/python3.12/site-packages/boltons/timeutils.py:426
../../../../home/saimidu/miniconda3/envs/sagemaker-distribution/lib/python3.12/site-packages/boltons/timeutils.py:426
../../../../home/saimidu/miniconda3/envs/sagemaker-distribution/lib/python3.12/site-packages/boltons/timeutils.py:426
../../../../home/saimidu/miniconda3/envs/sagemaker-distribution/lib/python3.12/site-packages/boltons/timeutils.py:426
../../../../home/saimidu/miniconda3/envs/sagemaker-distribution/lib/python3.12/site-packages/boltons/timeutils.py:426
../../../../home/saimidu/miniconda3/envs/sagemaker-distribution/lib/python3.12/site-packages/boltons/timeutils.py:426
../../../../home/saimidu/miniconda3/envs/sagemaker-distribution/lib/python3.12/site-packages/boltons/timeutils.py:426
  /home/saimidu/miniconda3/envs/sagemaker-distribution/lib/python3.12/site-packages/boltons/timeutils.py:426: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    EPOCH_NAIVE = datetime.utcfromtimestamp(0)

src/utils.py:4
src/utils.py:4
src/utils.py:4
src/utils.py:4
src/utils.py:4
src/utils.py:4
src/utils.py:4
src/utils.py:4
  /local/home/saimidu/sagemaker-distribution/src/utils.py:4: DeprecationWarning: conda.cli.python_api is deprecated and will be removed in 24.9. Use `conda.testing.conda_cli` instead.
    import conda.cli.python_api

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================================================================== 1 passed, 16 warnings in 62.99s (0:01:02) ===================================================================================================
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
