### PR TITLE
Add a tool for generating package dependency report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -24,9 +24,9 @@ body:
     label: 🐛 Describe the bug
     description: |
       Please provide a clear and concise description of what the bug is.
-      
+
       If relevant, add a minimal example so that we can reproduce the error by running the code. It is very important for the snippet to be as succinct (minimal) as possible, so please take time to trim down any irrelevant code to help us debug efficiently. We are going to copy-paste your code and we expect to get the same result as you did: avoid any external data, and include the relevant imports, etc.
- 
+
       Please also paste or describe the results you observe.
       If you observe an error, please paste the error message including the **full** traceback of the exception. It may be relevant to wrap error messages in ```` ```triple quotes blocks``` ````.
     placeholder: |

--- a/.github/workflows/PR_TEMPLATE.md
+++ b/.github/workflows/PR_TEMPLATE.md
@@ -1,4 +1,5 @@
 This pull request was created by GitHub Actions/AWS CodeBuild! Before merging, please do the following:
 - [ ] Review changelog/staleness report.
+- [ ] (Only for Minor/Major version releases) Review python package dependency and size report.
 - [ ] Review build/test results by clicking *Build Logs* in CI Report (be patient, tests take ~4hr).
 - [ ] Review ECR Scan results.

--- a/src/changelog_generator.py
+++ b/src/changelog_generator.py
@@ -2,39 +2,7 @@ import os
 
 from semver import Version
 
-from utils import get_dir_for_version, get_match_specs, get_semver
-
-
-def _derive_changeset(target_version_dir, source_version_dir, image_config) -> (dict[str, list[str]], dict[str, str]):
-    env_in_file_name = image_config["build_args"]["ENV_IN_FILENAME"]
-    env_out_file_name = image_config["env_out_filename"]
-    required_packages_from_target = get_match_specs(target_version_dir + "/" + env_in_file_name).keys()
-    target_match_spec_out = get_match_specs(target_version_dir + "/" + env_out_file_name)
-    source_match_spec_out = get_match_specs(source_version_dir + "/" + env_out_file_name)
-
-    # Note: required_packages_from_source is not currently used.
-    # In the future, If we remove any packages from env.in, at that time required_packages_from_source will be needed.
-    # We only care about the packages which are present in the target version env.in file
-    installed_packages_from_target = {
-        k: str(v.get("version")).removeprefix("==")
-        for k, v in target_match_spec_out.items()
-        if k in required_packages_from_target
-    }
-    # Note: A required package in the target version might not be a required package in the source version
-    # But source version could still have this package pulled as a dependency of a dependency.
-    installed_packages_from_source = {
-        k: str(v.get("version")).removeprefix("==")
-        for k, v in source_match_spec_out.items()
-        if k in required_packages_from_target
-    }
-    upgrades = {
-        k: [installed_packages_from_source[k], v]
-        for k, v in installed_packages_from_target.items()
-        if k in installed_packages_from_source and installed_packages_from_source[k] != v
-    }
-    new_packages = {k: v for k, v in installed_packages_from_target.items() if k not in installed_packages_from_source}
-    # TODO: Add support for removed packages.
-    return upgrades, new_packages
+from utils import derive_changeset, get_dir_for_version, get_semver
 
 
 def generate_change_log(target_version: Version, image_config):
@@ -48,7 +16,7 @@ def generate_change_log(target_version: Version, image_config):
     source_version = get_semver(source_patch_version)
     source_version_dir = get_dir_for_version(source_version)
     image_type = image_config["image_type"]
-    upgrades, new_packages = _derive_changeset(target_version_dir, source_version_dir, image_config)
+    upgrades, new_packages = derive_changeset(target_version_dir, source_version_dir, image_config)
     with open(f"{target_version_dir}/CHANGELOG-{image_type}.md", "w") as f:
         f.write("# Change log: " + str(target_version) + "(" + image_type + ")\n\n")
         if len(upgrades) != 0:

--- a/src/main.py
+++ b/src/main.py
@@ -23,6 +23,7 @@ from dependency_upgrader import (
 from package_report import (
     generate_package_size_report,
     generate_package_staleness_report,
+    generate_package_dependency_report
 )
 from release_notes_generator import generate_release_notes
 from utils import (
@@ -425,6 +426,16 @@ def get_arg_parser():
         "--validate",
         action="store_true",
         help="Validate package size delta and raise error if the validation failed.",
+    )
+    package_dependency_parser = subparsers.add_parser(
+        "generate-dependency-report",
+        help="Generates package dependency report for each of newly introcuded packages in the target image version.",
+    )
+    package_dependency_parser.set_defaults(func=generate_package_dependency_report)
+    package_dependency_parser.add_argument(
+        "--target-patch-version",
+        required=True,
+        help="Specify the target patch version for which the package dependency report needs to be generated.",
     )
     return parser
 

--- a/src/main.py
+++ b/src/main.py
@@ -21,9 +21,9 @@ from dependency_upgrader import (
     _get_dependency_upper_bound_for_runtime_upgrade,
 )
 from package_report import (
+    generate_package_dependency_report,
     generate_package_size_report,
     generate_package_staleness_report,
-    generate_package_dependency_report
 )
 from release_notes_generator import generate_release_notes
 from utils import (

--- a/src/package_report.py
+++ b/src/package_report.py
@@ -237,11 +237,8 @@ def _generate_python_package_dependency_report(image_config, base_version_dir, t
             # Pull package metadata from conda-forge and dump into json file
             search_result = conda.cli.python_api.run_command("search", str(target_match_spec_out), "--json")
             package_metadata = json.loads(search_result[0])[package][0]
-            results[package] = {
-                "version": package_metadata["version"],
-                "depends": package_metadata["depends"]
-            }
-    
+            results[package] = {"version": package_metadata["version"], "depends": package_metadata["depends"]}
+
     print(
         create_markdown_table(
             ["Package", "Version in the Target Image", "Dependencies"],

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -9,7 +9,6 @@ pytestmark = pytest.mark.unit
 import os
 from unittest.mock import MagicMock, Mock, patch
 
-from changelog_generator import _derive_changeset
 from config import _image_generator_configs
 from main import (
     _get_config_for_image,
@@ -25,7 +24,7 @@ from release_notes_generator import (
     _get_image_type_package_metadata,
     _get_package_to_image_type_mapping,
 )
-from utils import get_semver
+from utils import derive_changeset, get_semver
 
 
 class CreateVersionArgs:
@@ -629,7 +628,7 @@ def test_derive_changeset(tmp_path):
     _create_docker_cpu_env_out_file(target_version_dir + "/cpu.env.out", package_metadata=target_env_out_packages)
     expected_upgrades = {"ipykernel": ["6.21.3", "6.21.6"]}
     expected_new_packages = {"boto3": "1.2"}
-    actual_upgrades, actual_new_packages = _derive_changeset(
+    actual_upgrades, actual_new_packages = derive_changeset(
         target_version_dir, source_version_dir, _image_generator_configs[1]
     )
     assert expected_upgrades == actual_upgrades

--- a/test/test_package_report.py
+++ b/test/test_package_report.py
@@ -8,9 +8,9 @@ from unittest.mock import patch
 
 from config import _image_generator_configs
 from package_report import (
+    _generate_python_package_dependency_report,
     _generate_python_package_size_report_per_image,
     _get_installed_package_versions_and_conda_versions,
-    _generate_python_package_dependency_report,
 )
 from utils import get_match_specs, get_semver
 
@@ -204,7 +204,9 @@ def test_generate_package_dependency_report(mock_conda_command, tmp_path, capsys
         0,
     )
 
-    _generate_python_package_dependency_report(_image_generator_configs[1], str(base_env_in_file_path), str(target_env_in_file_path))
+    _generate_python_package_dependency_report(
+        _image_generator_configs[1], str(base_env_in_file_path), str(target_env_in_file_path)
+    )
 
     captured = capsys.readouterr()
     print(captured.out)

--- a/test/test_package_report.py
+++ b/test/test_package_report.py
@@ -181,7 +181,6 @@ def test_generate_package_size_report_when_base_version_is_not_present(capsys):
 
 
 @patch("conda.cli.python_api.run_command")
-# @patch("main.get_dir_for_version")
 def test_generate_package_dependency_report(mock_conda_command, tmp_path, capsys):
     base_env_in_file_path = tmp_path / "base"
     base_env_in_file_path.mkdir()
@@ -189,14 +188,6 @@ def test_generate_package_dependency_report(mock_conda_command, tmp_path, capsys
     target_env_in_file_path = tmp_path / "target"
     target_env_in_file_path.mkdir()
     _create_target_env_in_docker_file(target_env_in_file_path / "cpu.env.in")
-
-    # mocker.patch("conda.cli.python_api.run_command", side_effect=(
-    #     '{"sagemaker-headless-execution-driver":[{"version":"0.0.13","depends":["nbconvert","papermill >=2.4","python >3.8"]}]}',
-    #     "",
-    #     0,
-    # ))
-
-    # mock_get_dir.return_value=base_env_in_file_path
 
     mock_conda_command.return_value = (
         '{"sagemaker-headless-execution-driver":[{"version":"0.0.13","depends":["nbconvert","papermill >=2.4","python >3.8"]}]}',
@@ -209,7 +200,6 @@ def test_generate_package_dependency_report(mock_conda_command, tmp_path, capsys
     )
 
     captured = capsys.readouterr()
-    print(captured.out)
     # Assert dependency report for newly added packages
     assert "sagemaker-headless-execution-driver|0.0.13|['nbconvert', 'papermill >=2.4', 'python >3.8']" in captured.out
 


### PR DESCRIPTION
Add a tool for generating package dependency report for newly introduced packages in an image. It will provide a full list of dependencies and required versions for new marquee packages in the image release.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
