### PR TITLE
fix: Update openssl source code url

### DIFF
--- a/template/v0/Dockerfile
+++ b/template/v0/Dockerfile
@@ -111,8 +111,8 @@ WORKDIR "/home/${NB_USER}"
 # see https://github.com/openssl/openssl/blob/master/README-FIPS.md https://www.openssl.org/source/
 RUN INSTALLED_SSL=$(micromamba list | grep openssl | tr -s ' ' | cut -d ' ' -f 3 | head -n 1) && \
     # download source code for installed, and FIPS validated openssl versions
-    curl -L https://www.openssl.org/source/openssl-$FIPS_VALIDATED_SSL.tar.gz > openssl-$FIPS_VALIDATED_SSL.tar.gz &&  \
-    curl -L https://www.openssl.org/source/openssl-$INSTALLED_SSL.tar.gz > openssl-$INSTALLED_SSL.tar.gz &&  \
+    curl -L https://github.com/openssl/openssl/releases/download/openssl-$FIPS_VALIDATED_SSL/openssl-$FIPS_VALIDATED_SSL.tar.gz > openssl-$FIPS_VALIDATED_SSL.tar.gz &&  \
+    curl -L https://github.com/openssl/openssl/releases/download/openssl-$INSTALLED_SSL/openssl-$INSTALLED_SSL.tar.gz > openssl-$INSTALLED_SSL.tar.gz &&  \
     tar -xf openssl-$FIPS_VALIDATED_SSL.tar.gz && tar -xf openssl-$INSTALLED_SSL.tar.gz && cd openssl-$FIPS_VALIDATED_SSL && \
     # Configure both versions to enable FIPS and build
     ./Configure enable-fips --prefix=/opt/conda --openssldir=/opt/conda/ssl && make && \

--- a/template/v1/Dockerfile
+++ b/template/v1/Dockerfile
@@ -159,8 +159,8 @@ WORKDIR "/home/${NB_USER}"
 # see https://github.com/openssl/openssl/blob/master/README-FIPS.md https://www.openssl.org/source/
 RUN INSTALLED_SSL=$(micromamba list | grep openssl | tr -s ' ' | cut -d ' ' -f 3 | head -n 1) && \
     # download source code for installed, and FIPS validated openssl versions
-    curl -L https://www.openssl.org/source/openssl-$FIPS_VALIDATED_SSL.tar.gz > openssl-$FIPS_VALIDATED_SSL.tar.gz &&  \
-    curl -L https://www.openssl.org/source/openssl-$INSTALLED_SSL.tar.gz > openssl-$INSTALLED_SSL.tar.gz &&  \
+    curl -L https://github.com/openssl/openssl/releases/download/openssl-$FIPS_VALIDATED_SSL/openssl-$FIPS_VALIDATED_SSL.tar.gz > openssl-$FIPS_VALIDATED_SSL.tar.gz &&  \
+    curl -L https://github.com/openssl/openssl/releases/download/openssl-$INSTALLED_SSL/openssl-$INSTALLED_SSL.tar.gz > openssl-$INSTALLED_SSL.tar.gz &&  \
     tar -xf openssl-$FIPS_VALIDATED_SSL.tar.gz && tar -xf openssl-$INSTALLED_SSL.tar.gz && cd openssl-$FIPS_VALIDATED_SSL && \
     # Configure both versions to enable FIPS and build
     ./Configure enable-fips --prefix=/opt/conda --openssldir=/opt/conda/ssl && make && \

--- a/template/v2/Dockerfile
+++ b/template/v2/Dockerfile
@@ -109,8 +109,8 @@ RUN if [[ -z $ARG_BASED_ENV_IN_FILENAME ]] ; \
     # see https://github.com/openssl/openssl/blob/master/README-FIPS.md https://www.openssl.org/source/
     INSTALLED_SSL=$(micromamba list | grep openssl | tr -s ' ' | cut -d ' ' -f 3 | head -n 1) && \
     # download source code for installed, and FIPS validated openssl versions
-    curl -L https://www.openssl.org/source/openssl-$FIPS_VALIDATED_SSL.tar.gz > openssl-$FIPS_VALIDATED_SSL.tar.gz &&  \
-    curl -L https://www.openssl.org/source/openssl-$INSTALLED_SSL.tar.gz > openssl-$INSTALLED_SSL.tar.gz &&  \
+    curl -L https://github.com/openssl/openssl/releases/download/openssl-$FIPS_VALIDATED_SSL/openssl-$FIPS_VALIDATED_SSL.tar.gz > openssl-$FIPS_VALIDATED_SSL.tar.gz &&  \
+    curl -L https://github.com/openssl/openssl/releases/download/openssl-$INSTALLED_SSL/openssl-$INSTALLED_SSL.tar.gz > openssl-$INSTALLED_SSL.tar.gz &&  \
     tar -xf openssl-$FIPS_VALIDATED_SSL.tar.gz && tar -xf openssl-$INSTALLED_SSL.tar.gz && cd openssl-$FIPS_VALIDATED_SSL && \
     # Configure both versions to enable FIPS and build
     ./Configure enable-fips --prefix=/opt/conda --openssldir=/opt/conda/ssl && make && \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Previously we pull openssl source code from openssl.org, as part of installing FIPS provider and testing. It seems with newer versions they've stopped publishing here, but all versions are available on github.com. This was blocking 1.10.1 build, and this change unblocked. Confirmed FIPS module is still working.

Note: Future patch releases will run into this failure. We don't want to edit the already released images' dockerfiles, so we'll need to update each patch's Dockerfile as we release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
