### PR TITLE
Add docker cli to SMD

### DIFF
--- a/build_artifacts/v2/v2.1/v2.1.0/cpu.additional_packages_env.in
+++ b/build_artifacts/v2/v2.1/v2.1.0/cpu.additional_packages_env.in
@@ -1,0 +1,2 @@
+#Add any additional packages here
+conda-forge::docker-cli[version='>=27.1.1']

--- a/build_artifacts/v2/v2.1/v2.1.0/gpu.additional_packages_env.in
+++ b/build_artifacts/v2/v2.1/v2.1.0/gpu.additional_packages_env.in
@@ -1,0 +1,2 @@
+#Add any additional packages here
+conda-forge::docker-cli[version='>=27.1.1']

--- a/test/test_artifacts/v2/docker-cli.test.Dockerfile
+++ b/test/test_artifacts/v2/docker-cli.test.Dockerfile
@@ -1,0 +1,9 @@
+ARG SAGEMAKER_DISTRIBUTION_IMAGE
+FROM $SAGEMAKER_DISTRIBUTION_IMAGE
+
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+
+COPY --chown=$MAMBA_USER:$MAMBA_USER scripts/run_docker_cli_tests.sh ./
+RUN chmod +x run_docker_cli_tests.sh
+
+CMD ["./run_docker_cli_tests.sh"]

--- a/test/test_artifacts/v2/scripts/run_docker_cli_tests.sh
+++ b/test/test_artifacts/v2/scripts/run_docker_cli_tests.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Function to check if Docker CLI is installed
+function check_docker_installed {
+    if ! command -v docker &> /dev/null; then
+        echo "Docker CLI is not installed."
+        exit 1
+    else
+        echo "Docker CLI is installed."
+    fi
+}
+# Function to validate Docker can execute basic commands
+function check_docker_functionality {
+    # Try running a simple Docker command
+    if docker --version &> /dev/null; then
+        echo "Docker CLI is functioning correctly."
+    else
+        echo "Docker CLI is not functioning correctly."
+        exit 1
+    fi
+}
+# Run the checks
+check_docker_installed
+check_docker_functionality
+echo "Docker CLI validation successful."

--- a/test/test_dockerfile_based_harness.py
+++ b/test/test_dockerfile_based_harness.py
@@ -47,6 +47,7 @@ _docker_client = docker.from_env()
         ("langchain-aws.test.Dockerfile", ["langchain-aws"]),
         ("mlflow.test.Dockerfile", ["mlflow"]),
         ("jupyter-activity-monitor-extension.test.Dockerfile", ["jupyter-activity-monitor-extension"]),
+        ("docker-cli.test.Dockerfile", ["docker-cli"]),
     ],
 )
 def test_dockerfiles_for_cpu(
@@ -91,6 +92,7 @@ def test_dockerfiles_for_cpu(
         ("sagemaker-mlflow.test.Dockerfile", ["sagemaker-mlflow"]),
         ("jupyter-activity-monitor-extension.test.Dockerfile", ["jupyter-activity-monitor-extension"]),
         ("gpu-dependencies.test.Dockerfile", ["pytorch", "tensorflow"]),
+        ("docker-cli.test.Dockerfile", ["docker-cli"]),
     ],
 )
 def test_dockerfiles_for_gpu(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Added the package to the {cpu/gpu}.additional_packages_env.in files
- Added import test for the jupyter-activity-monitor-extension extension package
- Built the images successfully and tested on the image. Results were as expected.

conda-forge: https://anaconda.org/conda-forge/docker-cli

Test results:
```
dev-dsk-cindyxl-2a-78c20928 % python -m pytest -n auto -m cpu -vv -rs -k "docker-cli" --local-image-version 2.1.0           
======================================================= test session starts =======================================================
platform linux -- Python 3.12.7, pytest-8.3.3, pluggy-1.5.0 -- /home/cindyxl/anaconda3/envs/sagemaker-distribution/bin/python
cachedir: .pytest_cache
rootdir: /local/home/cindyxl/workplace/CurrentProject/dockerSMD2/sagemaker-distribution
configfile: pytest.ini
plugins: mock-3.14.0, xdist-3.6.1
8 workers [1 item]      
scheduling tests via LoadScheduling

test/test_dockerfile_based_harness.py::test_dockerfiles_for_cpu[docker-cli.test.Dockerfile-required_packages30] 
[gw0] [100%] PASSED test/test_dockerfile_based_harness.py::test_dockerfiles_for_cpu[docker-cli.test.Dockerfile-required_packages30] 

======================================================== warnings summary =========================================================
../../../../../../../home/cindyxl/anaconda3/envs/sagemaker-distribution/lib/python3.12/site-packages/boltons/timeutils.py:426
../../../../../../../home/cindyxl/anaconda3/envs/sagemaker-distribution/lib/python3.12/site-packages/boltons/timeutils.py:426
../../../../../../../home/cindyxl/anaconda3/envs/sagemaker-distribution/lib/python3.12/site-packages/boltons/timeutils.py:426
../../../../../../../home/cindyxl/anaconda3/envs/sagemaker-distribution/lib/python3.12/site-packages/boltons/timeutils.py:426
../../../../../../../home/cindyxl/anaconda3/envs/sagemaker-distribution/lib/python3.12/site-packages/boltons/timeutils.py:426
../../../../../../../home/cindyxl/anaconda3/envs/sagemaker-distribution/lib/python3.12/site-packages/boltons/timeutils.py:426
../../../../../../../home/cindyxl/anaconda3/envs/sagemaker-distribution/lib/python3.12/site-packages/boltons/timeutils.py:426
../../../../../../../home/cindyxl/anaconda3/envs/sagemaker-distribution/lib/python3.12/site-packages/boltons/timeutils.py:426
  /home/cindyxl/anaconda3/envs/sagemaker-distribution/lib/python3.12/site-packages/boltons/timeutils.py:426: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    EPOCH_NAIVE = datetime.utcfromtimestamp(0)

src/utils.py:4
src/utils.py:4
src/utils.py:4
src/utils.py:4
src/utils.py:4
src/utils.py:4
src/utils.py:4
src/utils.py:4
  /local/home/cindyxl/workplace/CurrentProject/dockerSMD2/sagemaker-distribution/src/utils.py:4: DeprecationWarning: conda.cli.python_api is deprecated and will be removed in 25.9. Use `conda.testing.conda_cli` instead.
    import conda.cli.python_api

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================= 1 passed, 16 warnings in 11.68s =================================================
(sagemaker-distribution) 
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
