### PR TITLE
add amazon q and update aws toolkit code editor extensions

### DIFF
--- a/template/v2/dirs/etc/code-editor/extensions.txt
+++ b/template/v2/dirs/etc/code-editor/extensions.txt
@@ -1,3 +1,4 @@
 https://open-vsx.org/api/ms-toolsai/jupyter/2024.9.1/file/ms-toolsai.jupyter-2024.9.1.vsix
 https://open-vsx.org/api/ms-python/python/2024.16.1/file/ms-python.python-2024.16.1.vsix
-https://open-vsx.org/api/amazonwebservices/aws-toolkit-vscode/1.99.0/file/amazonwebservices.aws-toolkit-vscode-1.99.0.vsix
+https://open-vsx.org/api/amazonwebservices/aws-toolkit-vscode/3.30.0/file/amazonwebservices.aws-toolkit-vscode-3.30.0.vsix
+https://open-vsx.org/api/amazonwebservices/amazon-q-vscode/1.32.0/file/amazonwebservices.amazon-q-vscode-1.32.0.vsix

--- a/template/v3/dirs/etc/code-editor/extensions.txt
+++ b/template/v3/dirs/etc/code-editor/extensions.txt
@@ -1,3 +1,4 @@
 https://open-vsx.org/api/ms-toolsai/jupyter/2024.9.1/file/ms-toolsai.jupyter-2024.9.1.vsix
 https://open-vsx.org/api/ms-python/python/2024.16.1/file/ms-python.python-2024.16.1.vsix
-https://open-vsx.org/api/amazonwebservices/aws-toolkit-vscode/1.99.0/file/amazonwebservices.aws-toolkit-vscode-1.99.0.vsix
+https://open-vsx.org/api/amazonwebservices/aws-toolkit-vscode/3.30.0/file/amazonwebservices.aws-toolkit-vscode-3.30.0.vsix
+https://open-vsx.org/api/amazonwebservices/amazon-q-vscode/1.32.0/file/amazonwebservices.amazon-q-vscode-1.32.0.vsix


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add Amazon Q Code Editor extension v1.32.0 - https://open-vsx.org/extension/amazonwebservices/amazon-q-vscode
- Update AWS Toolkit Code Editor extension to v3.30.0 - https://open-vsx.org/extension/amazonwebservices/aws-toolkit-vscode


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
