### PR TITLE
Bhavyssh/tot image size report

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -420,7 +420,7 @@ def get_arg_parser():
     )
     package_size_parser = subparsers.add_parser(
         "generate-size-report",
-        help="Generates package size report for each of the packages in the given " "image version.",
+        help="Generates toatl image size and package size report for each of the packages in the given " "image version.",
     )
     package_size_parser.set_defaults(func=generate_package_size_report)
     package_size_parser.add_argument(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Added functionality : `get_image_size` function in package_report.py to calculate total Image size of the image with respect to its base image and it will generates report for GPU and CPU configurations.
2. Added `_generate_image_size_report` function to print the report in desired format.
3. Integrated image size reporting into the same function : `generate_package_size_report` for simplicity of having size reports in same place.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
