### PR TITLE
Added comment in autogluon test script.

### DIFF
--- a/test/test_artifacts/v0/scripts/run_autogluon_tests.sh
+++ b/test/test_artifacts/v0/scripts/run_autogluon_tests.sh
@@ -13,5 +13,6 @@ ret=$?
 
 if [ $ret -eq 0 ]
 then
+    echo "This notebook only supports a single GPU setup. Running on multi-GPU systems may lead to unexpected errors"
     jupyter nbconvert --execute --to python docs/tutorials/multimodal/multimodal_prediction/multimodal-quick-start.ipynb
 fi

--- a/test/test_artifacts/v1/scripts/run_autogluon_tests.sh
+++ b/test/test_artifacts/v1/scripts/run_autogluon_tests.sh
@@ -13,5 +13,6 @@ ret=$?
 
 if [ $ret -eq 0 ]
 then
+    echo "This notebook only supports a single GPU setup. Running on multi-GPU systems may lead to unexpected errors"
     jupyter nbconvert --execute --to python docs/tutorials/multimodal/multimodal_prediction/multimodal-quick-start.ipynb
 fi

--- a/test/test_artifacts/v2/scripts/run_autogluon_tests.sh
+++ b/test/test_artifacts/v2/scripts/run_autogluon_tests.sh
@@ -13,6 +13,6 @@ ret=$?
 
 if [ $ret -eq 0 ]
 then
-    # Note: This notebook only supports a single GPU setup. Running on multi-GPU systems may lead to errors.
+    echo "This notebook only supports a single GPU setup. Running on multi-GPU systems may lead to unexpected errors"
     jupyter nbconvert --execute --to python docs/tutorials/multimodal/multimodal_prediction/multimodal-quick-start.ipynb
 fi

--- a/test/test_artifacts/v2/scripts/run_autogluon_tests.sh
+++ b/test/test_artifacts/v2/scripts/run_autogluon_tests.sh
@@ -13,5 +13,6 @@ ret=$?
 
 if [ $ret -eq 0 ]
 then
+    # Note: This notebook only supports a single GPU setup. Running on multi-GPU systems may lead to errors.
     jupyter nbconvert --execute --to python docs/tutorials/multimodal/multimodal_prediction/multimodal-quick-start.ipynb
 fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added comment in autogluon test case script regarding  failure of in multi-GPU env as  multimodal-quick-start.ipynb supports single GPU env. It fails/gives unexpected error in Multi-GPU env due DDP(Distributed Data Parallel) while running training phase.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
