### PR TITLE
feat: Ensure micromamba meets minimum required version during build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 .idea
 .DS_Store
+.vscode

--- a/template/v0/Dockerfile
+++ b/template/v0/Dockerfile
@@ -18,8 +18,19 @@ ENV SAGEMAKER_LOGGING_DIR="/var/log/sagemaker/"
 ENV STUDIO_LOGGING_DIR="/var/log/studio/"
 ENV EDITOR="nano"
 ENV IMAGE_VERSION=$IMAGE_VERSION
+ENV PINNED_MICROMAMBA_MINOR_VERSION="1.5.*"
 
 USER root
+# Upgrade micromamba to the latest patch version in the pinned minor version range, if applicable
+RUN CURRENT_MICROMAMBA_VERSION=$(micromamba --version) && \
+    echo "Current micromamba version: $CURRENT_MICROMAMBA_VERSION" && \
+    if [[ "$CURRENT_MICROMAMBA_VERSION" == $PINNED_MICROMAMBA_MINOR_VERSION ]]; then \
+        echo "Upgrading micromamba to the latest $PINNED_MICROMAMBA_MINOR_VERSION version..." && \
+        micromamba self-update -c conda-forge --version "$PINNED_MICROMAMBA_MINOR_VERSION"; \
+    else \
+        echo "Micromamba is already at version $CURRENT_MICROMAMBA_VERSION (outside $PINNED_MICROMAMBA_MINOR_VERSION). No upgrade performed."; \
+    fi
+
 RUN usermod "--login=${NB_USER}" "--home=/home/${NB_USER}" --move-home "-u ${NB_UID}" "${MAMBA_USER}" && \
     groupmod "--new-name=${NB_USER}" --non-unique "-g ${NB_GID}" "${MAMBA_USER}" && \
     # Update the expected value of MAMBA_USER for the

--- a/template/v1/Dockerfile
+++ b/template/v1/Dockerfile
@@ -21,8 +21,19 @@ ENV SAGEMAKER_LOGGING_DIR="/var/log/sagemaker/"
 ENV STUDIO_LOGGING_DIR="/var/log/studio/"
 ENV EDITOR="nano"
 ENV IMAGE_VERSION=$IMAGE_VERSION
+ENV PINNED_MICROMAMBA_MINOR_VERSION="1.5.*"
 
 USER root
+# Upgrade micromamba to the latest patch version in the pinned minor version range, if applicable
+RUN CURRENT_MICROMAMBA_VERSION=$(micromamba --version) && \
+    echo "Current micromamba version: $CURRENT_MICROMAMBA_VERSION" && \
+    if [[ "$CURRENT_MICROMAMBA_VERSION" == $PINNED_MICROMAMBA_MINOR_VERSION ]]; then \
+        echo "Upgrading micromamba to the latest $PINNED_MICROMAMBA_MINOR_VERSION version..." && \
+        micromamba self-update -c conda-forge --version "$PINNED_MICROMAMBA_MINOR_VERSION"; \
+    else \
+        echo "Micromamba is already at version $CURRENT_MICROMAMBA_VERSION (outside $PINNED_MICROMAMBA_MINOR_VERSION). No upgrade performed."; \
+    fi
+    
 RUN usermod "--login=${NB_USER}" "--home=/home/${NB_USER}" --move-home "-u ${NB_UID}" "${MAMBA_USER}" && \
     groupmod "--new-name=${NB_USER}" --non-unique "-g ${NB_GID}" "${MAMBA_USER}" && \
     # Update the expected value of MAMBA_USER for the

--- a/template/v2/Dockerfile
+++ b/template/v2/Dockerfile
@@ -23,20 +23,18 @@ ENV SAGEMAKER_LOGGING_DIR="/var/log/sagemaker/"
 ENV STUDIO_LOGGING_DIR="/var/log/studio/"
 ENV EDITOR="nano"
 ENV IMAGE_VERSION=$IMAGE_VERSION
-ENV MIN_REQUIRED_MICROMAMBA_VERSION=${MIN_REQUIRED_MICROMAMBA_VERSION}
+ENV PINNED_MICROMAMBA_MINOR_VERSION="1.5.*"
 
 USER root
-
-# Compare the current micromamba version with the minimum required version, and only upgrade if strictly lower to avoid downgrades.
+# Upgrade micromamba to the latest patch version in the pinned minor version range, if applicable
 RUN CURRENT_MICROMAMBA_VERSION=$(micromamba --version) && \
-    LOWEST_MICROMAMBA_VERSION=$(printf '%s\n%s' "$MIN_REQUIRED_MICROMAMBA_VERSION" "$CURRENT_MICROMAMBA_VERSION" | sort -V | head -n 1) && \
-    if [ "$LOWEST_MICROMAMBA_VERSION" = "$CURRENT_MICROMAMBA_VERSION" ] && [ "$CURRENT_MICROMAMBA_VERSION" != "$MIN_REQUIRED_MICROMAMBA_VERSION" ]; then \
-        echo "Upgrading micromamba from $CURRENT_MICROMAMBA_VERSION to $MIN_REQUIRED_MICROMAMBA_VERSION..." && \
-        micromamba self-update -c conda-forge --version "$MIN_REQUIRED_MICROMAMBA_VERSION"; \
+    echo "Current micromamba version: $CURRENT_MICROMAMBA_VERSION" && \
+    if [[ "$CURRENT_MICROMAMBA_VERSION" == $PINNED_MICROMAMBA_MINOR_VERSION ]]; then \
+        echo "Upgrading micromamba to the latest $PINNED_MICROMAMBA_MINOR_VERSION version..." && \
+        micromamba self-update -c conda-forge --version "$PINNED_MICROMAMBA_MINOR_VERSION"; \
     else \
-        echo "Micromamba is already $MIN_REQUIRED_MICROMAMBA_VERSION or higher (current: $CURRENT_MICROMAMBA_VERSION). No update needed."; \
+        echo "Micromamba is already at version $CURRENT_MICROMAMBA_VERSION (outside $PINNED_MICROMAMBA_MINOR_VERSION). No upgrade performed."; \
     fi
-
 
 RUN usermod "--login=${NB_USER}" "--home=/home/${NB_USER}" --move-home "-u ${NB_UID}" "${MAMBA_USER}" && \
     groupmod "--new-name=${NB_USER}" --non-unique "-g ${NB_GID}" "${MAMBA_USER}" && \

--- a/template/v2/Dockerfile
+++ b/template/v2/Dockerfile
@@ -17,13 +17,27 @@ ARG NB_GID=100
 
 # https://www.openssl.org/source/
 ARG FIPS_VALIDATED_SSL=3.0.8
+ARG MIN_REQUIRED_MICROMAMBA_VERSION=1.5.11
 
 ENV SAGEMAKER_LOGGING_DIR="/var/log/sagemaker/"
 ENV STUDIO_LOGGING_DIR="/var/log/studio/"
 ENV EDITOR="nano"
 ENV IMAGE_VERSION=$IMAGE_VERSION
+ENV MIN_REQUIRED_MICROMAMBA_VERSION=${MIN_REQUIRED_MICROMAMBA_VERSION}
 
 USER root
+
+# Compare the current micromamba version with the minimum required version, and only upgrade if strictly lower to avoid downgrades.
+RUN CURRENT_MICROMAMBA_VERSION=$(micromamba --version) && \
+    LOWEST_MICROMAMBA_VERSION=$(printf '%s\n%s' "$MIN_REQUIRED_MICROMAMBA_VERSION" "$CURRENT_MICROMAMBA_VERSION" | sort -V | head -n 1) && \
+    if [ "$LOWEST_MICROMAMBA_VERSION" = "$CURRENT_MICROMAMBA_VERSION" ] && [ "$CURRENT_MICROMAMBA_VERSION" != "$MIN_REQUIRED_MICROMAMBA_VERSION" ]; then \
+        echo "Upgrading micromamba from $CURRENT_MICROMAMBA_VERSION to $MIN_REQUIRED_MICROMAMBA_VERSION..." && \
+        micromamba self-update -c conda-forge --version "$MIN_REQUIRED_MICROMAMBA_VERSION"; \
+    else \
+        echo "Micromamba is already $MIN_REQUIRED_MICROMAMBA_VERSION or higher (current: $CURRENT_MICROMAMBA_VERSION). No update needed."; \
+    fi
+
+
 RUN usermod "--login=${NB_USER}" "--home=/home/${NB_USER}" --move-home "-u ${NB_UID}" "${MAMBA_USER}" && \
     groupmod "--new-name=${NB_USER}" --non-unique "-g ${NB_GID}" "${MAMBA_USER}" && \
     # Update the expected value of MAMBA_USER for the

--- a/template/v3/Dockerfile
+++ b/template/v3/Dockerfile
@@ -15,12 +15,26 @@ ARG NB_GID=100
 
 # https://www.openssl.org/source/
 ARG FIPS_VALIDATED_SSL=3.0.8
+ARG MIN_REQUIRED_MICROMAMBA_VERSION=1.5.11
 
 ENV SAGEMAKER_LOGGING_DIR="/var/log/sagemaker/"
 ENV STUDIO_LOGGING_DIR="/var/log/studio/"
 ENV EDITOR="nano"
+ENV MIN_REQUIRED_MICROMAMBA_VERSION=${MIN_REQUIRED_MICROMAMBA_VERSION}
 
 USER root
+
+# Compare the current micromamba version with the minimum required version, and only upgrade if strictly lower to avoid downgrades.
+RUN CURRENT_MICROMAMBA_VERSION=$(micromamba --version) && \
+    LOWEST_MICROMAMBA_VERSION=$(printf '%s\n%s' "$MIN_REQUIRED_MICROMAMBA_VERSION" "$CURRENT_MICROMAMBA_VERSION" | sort -V | head -n 1) && \
+    if [ "$LOWEST_MICROMAMBA_VERSION" = "$CURRENT_MICROMAMBA_VERSION" ] && [ "$CURRENT_MICROMAMBA_VERSION" != "$MIN_REQUIRED_MICROMAMBA_VERSION" ]; then \
+        echo "Upgrading micromamba from $CURRENT_MICROMAMBA_VERSION to $MIN_REQUIRED_MICROMAMBA_VERSION..." && \
+        micromamba self-update -c conda-forge --version "$MIN_REQUIRED_MICROMAMBA_VERSION"; \
+    else \
+        echo "Micromamba is already $MIN_REQUIRED_MICROMAMBA_VERSION or higher (current: $CURRENT_MICROMAMBA_VERSION). No update needed."; \
+    fi
+
+
 RUN usermod "--login=${NB_USER}" "--home=/home/${NB_USER}" --move-home "-u ${NB_UID}" "${MAMBA_USER}" && \
     groupmod "--new-name=${NB_USER}" --non-unique "-g ${NB_GID}" "${MAMBA_USER}" && \
     # Update the expected value of MAMBA_USER for the


### PR DESCRIPTION
*Issue #, if available:* 
App cannot start if there is corrupted condarc file
https://t.corp.amazon.com/P162071398/information

*Motivation*
Upgrade mircromamba version to include the open source fix in 1.5.11 
Also jammy image tag is effective deprecated https://github.com/mamba-org/micromamba-docker/issues/573#issuecomment-2563138910
source: https://github.com/mamba-org/mamba/pull/3580

*Description of changes:*
- Added logic to compare the current micromamba version with a configurable minimum required version (MIN_REQUIRED_MICROMAMBA_VERSION, default: 1.5.11).
- Automatically upgrades micromamba if the installed version is strictly lower than the required version.
- Prevents unnecessary updates or downgrades if the current version already satisfies the requirement.
- Introduced ARG MIN_REQUIRED_MICROMAMBA_VERSION for flexibility during build time.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
