### PR TITLE
Move 1.10, 1.11, and 2.0 to Unsupported table

### DIFF
--- a/support_policy.md
+++ b/support_policy.md
@@ -23,10 +23,7 @@ The tables below lists the supported SageMaker Distribution image versions and t
 | 2.3.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.3-cpu  | Jul 27th, 2025 |
 | 2.2.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.2-cpu  | May 15th, 2025 |
 | 2.1.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.1-cpu  | Apr 25th, 2025 |
-| 2.0.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.0-cpu  | Feb 25th, 2025 |
 | 1.12.x        | public.ecr.aws/sagemaker/sagemaker-distribution:1.12-cpu | Jul 23rd, 2025 |
-| 1.11.x        | public.ecr.aws/sagemaker/sagemaker-distribution:1.11-cpu | Apr 1st, 2025  |
-| 1.10.x        | public.ecr.aws/sagemaker/sagemaker-distribution:1.10-cpu | Feb 5th, 2025  |
 
 ### GPU Images
 
@@ -35,10 +32,8 @@ The tables below lists the supported SageMaker Distribution image versions and t
 | 2.3.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.3-gpu  | Jul 27th, 2025 |
 | 2.2.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.2-gpu  | May 15th, 2025 |
 | 2.1.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.1-gpu  | Apr 25th, 2025 |
-| 2.0.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.0-gpu  | Feb 25th, 2025 |
 | 1.12.x        | public.ecr.aws/sagemaker/sagemaker-distribution:1.12-gpu | Jul 23rd, 2025 |
-| 1.11.x        | public.ecr.aws/sagemaker/sagemaker-distribution:1.11-gpu | Apr 1st, 2025  |
-| 1.10.x        | public.ecr.aws/sagemaker/sagemaker-distribution:1.10-gpu | Feb 5th, 2025  |
+
 
 ## Unsupported Image Versions
 The tables below list SageMaker Distribution Image versions that are no longer supportedand the dates when they reached end of support. AWS will not release any new functionality or security patch updates for these image versions. These unsupported versions will remain visible in the below table for 1 year after their end of support date.
@@ -47,6 +42,9 @@ The tables below list SageMaker Distribution Image versions that are no longer s
 
 | Image Version | ECR Image URI | End of Support Date |
 | :---:         | :---:         | :---:               |
+| 2.0.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.0-gpu  | Feb 25th, 2025   |
+| 1.11.x        | public.ecr.aws/sagemaker/sagemaker-distribution:1.11-gpu | Jan 8th, 2025    |
+| 1.10.x        | public.ecr.aws/sagemaker/sagemaker-distribution:1.10-gpu | Feb 5th, 2025    |
 | 1.9.x         | public.ecr.aws/sagemaker/sagemaker-distribution:1.9-cpu  | Jan 15th, 2025   |
 | 1.8.x         | public.ecr.aws/sagemaker/sagemaker-distribution:1.8-cpu  | Dec 31st, 2024   |
 | 1.7.x         | public.ecr.aws/sagemaker/sagemaker-distribution:1.7-cpu  | Dec 15th, 2024   |
@@ -68,6 +66,9 @@ The tables below list SageMaker Distribution Image versions that are no longer s
 ### GPU Images
 | Image Version | ECR Image URI | End of Support Date |
 | :---:         | :---:         | :---:               |
+| 2.0.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.0-gpu  | Feb 25th, 2025   |
+| 1.11.x        | public.ecr.aws/sagemaker/sagemaker-distribution:1.11-gpu | Jan 8th, 2025    |
+| 1.10.x        | public.ecr.aws/sagemaker/sagemaker-distribution:1.10-gpu | Feb 5th, 2025    |
 | 1.9.x         | public.ecr.aws/sagemaker/sagemaker-distribution:1.9-gpu  | Jan 15th, 2025   |
 | 1.8.x         | public.ecr.aws/sagemaker/sagemaker-distribution:1.8-gpu  | Dec 31st, 2024   |
 | 1.7.x         | public.ecr.aws/sagemaker/sagemaker-distribution:1.7-gpu  | Dec 15th, 2024   |


### PR DESCRIPTION
*Description of changes:*
Moved 1.10, 1.11, and 2.0 to Unsupported table.

1.10 is past EOS date, 2.0 is past EOS date. 

1.11 has not been able to be patched since 1/8 due to CVEs and should be added to the unsupported table with a date update

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
