### PR TITLE
Swallow PackagesNotFoundError when generating size report

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -2,8 +2,8 @@ import json
 import os
 
 import conda.cli.python_api
-from conda.exceptions import PackagesNotFoundError
 from conda.env.specs import RequirementsSpec
+from conda.exceptions import PackagesNotFoundError
 from conda.models.match_spec import MatchSpec
 from semver import Version
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -110,7 +110,9 @@ def pull_conda_package_metadata(image_config, image_artifact_dir):
                 package_metadata = json.loads(search_result[0])[package][0]
                 results[package] = {"version": package_metadata["version"], "size": package_metadata["size"]}
             except PackagesNotFoundError:
-                print(f"Failed to pull package metadata for {package}, {match_spec_out} from conda-forge, ignore. Potentially this package is broken.")
+                print(
+                    f"Failed to pull package metadata for {package}, {match_spec_out} from conda-forge, ignore. Potentially this package is broken."
+                )
     # Sort the pakcage sizes in decreasing order
     results = {k: v for k, v in sorted(results.items(), key=lambda item: item[1]["size"], reverse=True)}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Seeing `PackagesNotFoundError` blocking package size report generation, it happens when packages like https://anaconda.org/conda-forge/fmt/files have most of versions marked as `broken`.

Ignore such package and continue to check remaining ones in such case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
