### PR TITLE
Update the Q chat version for CodeEditor to 1.58.0

### DIFF
--- a/template/v2/dirs/etc/code-editor/extensions.txt
+++ b/template/v2/dirs/etc/code-editor/extensions.txt
@@ -1,4 +1,4 @@
 https://open-vsx.org/api/ms-toolsai/jupyter/2023.9.100/file/ms-toolsai.jupyter-2023.9.100.vsix
 https://open-vsx.org/api/ms-python/python/2023.20.0/file/ms-python.python-2023.20.0.vsix
 https://open-vsx.org/api/amazonwebservices/aws-toolkit-vscode/3.30.0/file/amazonwebservices.aws-toolkit-vscode-3.30.0.vsix
-https://open-vsx.org/api/amazonwebservices/amazon-q-vscode/1.32.0/file/amazonwebservices.amazon-q-vscode-1.32.0.vsix
+https://open-vsx.org/api/amazonwebservices/amazon-q-vscode/1.58.0/file/amazonwebservices.amazon-q-vscode-1.58.0.vsix

--- a/template/v3/dirs/etc/code-editor/extensions.txt
+++ b/template/v3/dirs/etc/code-editor/extensions.txt
@@ -1,4 +1,4 @@
 https://open-vsx.org/api/ms-toolsai/jupyter/2023.9.100/file/ms-toolsai.jupyter-2023.9.100.vsix
 https://open-vsx.org/api/ms-python/python/2023.20.0/file/ms-python.python-2023.20.0.vsix
 https://open-vsx.org/api/amazonwebservices/aws-toolkit-vscode/3.30.0/file/amazonwebservices.aws-toolkit-vscode-3.30.0.vsix
-https://open-vsx.org/api/amazonwebservices/amazon-q-vscode/1.32.0/file/amazonwebservices.amazon-q-vscode-1.32.0.vsix
+https://open-vsx.org/api/amazonwebservices/amazon-q-vscode/1.58.0/file/amazonwebservices.amazon-q-vscode-1.58.0.vsix


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update the Q chat version for CodeEditor to 1.58.0. Locally tested in SM AI and SMUS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.