### PR TITLE
Explicitly constraint build string for GPU packages in generated env.in files

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -159,8 +159,8 @@ def _create_new_version_conda_specs(
             out.append(f"conda-forge::{package_name}")
         else:
             channel = match_out.get("channel").channel_name
-            # E.g. "tensorflow ==2.17.0 cuda120py311h51447cc_202"
-            version_spec = match_out.spec
+            # Build string of the package, like "cuda120py311h51447cc_202".
+            build_string = match_out.spec.split(" ")[-1]
 
             min_version_inclusive = match_out.get("version")
             assert str(min_version_inclusive).startswith("==")
@@ -171,7 +171,7 @@ def _create_new_version_conda_specs(
             )
             version_constraint = f"version='>={min_version_inclusive}{max_version_str}'"
             # Explicitly constraint build string for GPU packages, like PyTorch, tensorflow.
-            if "cuda" in version_spec:
+            if "cuda" in build_string:
                 version_constraint += ",build='*cuda*'"
 
             out.append(f"{channel}::{package_name}[{version_constraint}]")


### PR DESCRIPTION
…in files

*Issue #, if available:*

*Description of changes:*
Explicitly constraint build string for GPU packages in generated env.in files.

For example, if the following line is in gpu.env.out of the base version:
```
https://conda.anaconda.org/conda-forge/linux-64/tensorflow-2.17.0-cuda120py311h51447cc_202.conda#908caf3811771b418ce0ff8a64bba9c3
```
Then the generated gpu.env.in should contain:
```
conda-forge::tensorflow[version='>=2.17.0,<3.0.0',build='*cuda*']
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
