### PR TITLE
Fix issue of SparkMagic config file not accessible in workflow

### DIFF
--- a/template/v2/dirs/etc/sagemaker-ui/kernels/kernel_launchers/python3_kernel_launcher.sh
+++ b/template/v2/dirs/etc/sagemaker-ui/kernels/kernel_launchers/python3_kernel_launcher.sh
@@ -3,9 +3,19 @@
 kernel_type=$2
 connection_file=$4
 
-sparkmagicHomeDir=/home/sagemaker-user/.sparkmagic
-mkdir -p $sparkmagicHomeDir
-config_file_path=${sparkmagicHomeDir}/config.json
+if [ ! -e "/opt/ml/metadata/resource-metadata.json" ] && [ -z "$SPARKMAGIC_CONF_DIR" ]; then
+    export SPARKMAGIC_CONF_DIR="$SM_EXECUTION_INPUT_PATH"
+fi
+
+if [ -n "$SPARKMAGIC_CONF_DIR" ]; then
+    mkdir -p $SPARKMAGIC_CONF_DIR
+    config_file_path=${SPARKMAGIC_CONF_DIR}/config.json
+else
+    sparkmagicHomeDir=${HOME}/.sparkmagic
+    mkdir -p $sparkmagicHomeDir
+    config_file_path=${sparkmagicHomeDir}/config.json
+fi
+
 if [ ! -f "$config_file_path" ]; then
     cat << EOT > "$config_file_path"
 {


### PR DESCRIPTION
In this commit we:
(1) ensure that we respect $SPARKMAGIC_CONF_DIR if set by user (2) if invoked from workflow and $SPARKMAGIC_CONF_DIR is not set, we set it to be the value of $SM_EXECUTION_INPUT_PATH

Test:
modify the script on space, set env vars of $SM_EXECUTION_INPUT_PATH and $SPARKMAGIC_CONF_DIR.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
