### PR TITLE
[Do Not Merge Yet] [SMUS] Enable session management plugin for JupyterLab

### DIFF
--- a/template/v2/dirs/etc/sagemaker-ui/jupyter/lab/settings/page_config.json
+++ b/template/v2/dirs/etc/sagemaker-ui/jupyter/lab/settings/page_config.json
@@ -4,7 +4,6 @@
       "@amzn/sagemaker-jupyterlab-emr-extension": true,
       "@amzn/sagemaker-jupyter-scheduler": true,
       "@amzn/sagemaker-jupyterlab-extension-common:panorama": true,
-      "@amzn/sagemaker-jupyterlab-extensions:sessionmanagement": true,
       "@amzn/sagemaker-jupyterlab-extensions:spacemenu": true,
       "@amzn/amazon_sagemaker_sql_editor": true,
       "@sagemaker-studio:EmrCluster": true,


### PR DESCRIPTION
** Description **
We enable session management plugin within SageMaker jupyterlab extension. This plugin would monitor SMUS user's IDE sessions and show a UI pop when user's session is about to expire in 15 minutes.

** Motivation **
This would help SMUS user's to renew their session once existing session is about to end. With this support, we would have parity with SageMaker AI in regards to JupyterIDE session management.

** Testing **
Enable plugin manually in SMUS SMD image and verified it works as expected

Issue #, if available:

Description of changes:

Do not merge yet - we are discussing within team whether or not to include it in latest release. (blocked on other changes)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
