### PR TITLE
Update sagemaker_studio_dataengineering_extensions tests

### DIFF
--- a/test/test_artifacts/v2/sagemaker_studio_dataengineering_extensions.test.Dockerfile
+++ b/test/test_artifacts/v2/sagemaker_studio_dataengineering_extensions.test.Dockerfile
@@ -12,6 +12,5 @@ RUN jupyter labextension list &> >(grep --color=never @amzn/sagemaker-connection
 RUN python -c "import sagemaker_ui_doc_manager_jl_plugin"
 RUN jupyter labextension list &>  >(grep --color=never @amzn/sagemaker-ui-doc-manager-jl-plugin) | grep  enabled
 
-COPY --chown=$MAMBA_USER:$MAMBA_USER scripts/run_sagemaker_studio_dataengineering_extensions_test.sh .
-RUN chmod +x run_sagemaker_studio_dataengineering_extensions_test.sh
-CMD ["./run_sagemaker_studio_dataengineering_extensions_test.sh"]
+
+RUN jupyter labextension list &>  >(grep --color=never sagemaker_sparkmonitor) | grep  enabled

--- a/test/test_artifacts/v2/scripts/run_sagemaker_studio_dataengineering_extensions_test.sh
+++ b/test/test_artifacts/v2/scripts/run_sagemaker_studio_dataengineering_extensions_test.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-pip install pytest pytest-jupyter
-SITE_PACKAGES=$(pip show amzn-sagemaker-studio-dataengineering-extensions | grep Location | awk '{print $2}')
-pytest -vv -r p $SITE_PACKAGES/sagemaker_studio_dataengineering_extensions || exit $?


### PR DESCRIPTION
Remove running the unit test, because the tests are not built into pypi and conda to minimize the size.
Function tests are covered by integ test/canary.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
