### PR TITLE
fix(GitClone): Fix git clone script to set the credential helper without passing args from the script invocation

### DIFF
--- a/template/v2/dirs/etc/sagemaker-ui/git_clone.sh
+++ b/template/v2/dirs/etc/sagemaker-ui/git_clone.sh
@@ -8,7 +8,6 @@ dataZoneDomainId=$(jq -r '.AdditionalMetadata.DataZoneDomainId' < $sourceMetaDat
 dataZoneUserId=$(jq -r '.AdditionalMetadata.DataZoneUserId' < $sourceMetaData)
 dataZoneEndPoint=$(jq -r '.AdditionalMetadata.DataZoneEndpoint' < $sourceMetaData)
 dataZoneProjectId=$(jq -r '.AdditionalMetadata.DataZoneProjectId' < $sourceMetaData)
-dataZoneDomainRegion=$(jq -r '.AdditionalMetadata.DataZoneDomainRegion' < $sourceMetaData)
 
 DEFAULT_DESTINATION_PATH=$HOME/src
 DESTINATION_PATH=${1:-$DEFAULT_DESTINATION_PATH}
@@ -48,10 +47,8 @@ if [[ -n "$cloneUrl" ]]; then
     if [[ "$cloneUrl" == *"codeconnections"* ]] || [[ "$cloneUrl" == *"codestar-connections"* ]]; then
         # Check if the DomainExecutionRoleCreds profile exists in the AWS config file
         if grep -q 'DomainExecutionRoleCreds' /home/sagemaker-user/.aws/config; then
-            # Configure Git to use the AWS CodeCommit credential helper with profile DomainExecutionRoleCreds
-            git config --global credential.helper "!aws --profile DomainExecutionRoleCreds --region $dataZoneDomainRegion codecommit credential-helper --ignore-host-check $@"
-            git config --global credential.UseHttpPath true
-             # Clone the repository using the cloneUrl and gitBranchName
+            /bin/bash /etc/sagemaker-ui/git_config.sh
+            # Clone the repository using the cloneUrl and gitBranchName
             git clone "$cloneUrl" $DESTINATION_PATH -b "$gitBranchName"
         fi
     else

--- a/template/v2/dirs/etc/sagemaker-ui/git_config.sh
+++ b/template/v2/dirs/etc/sagemaker-ui/git_config.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eux
+
+sourceMetaData=/opt/ml/metadata/resource-metadata.json
+dataZoneDomainRegion=$(jq -r '.AdditionalMetadata.DataZoneDomainRegion' < $sourceMetaData)
+
+# Configure Git to use the AWS CodeCommit credential helper with profile DomainExecutionRoleCreds
+git config --global credential.helper "!aws --profile DomainExecutionRoleCreds --region $dataZoneDomainRegion codecommit credential-helper --ignore-host-check $@"
+git config --global credential.UseHttpPath true


### PR DESCRIPTION
*Issue #, if available:*

## IMPORTANT NOTE TO SMD TEAM: This PR needs to be included in patch versions. Thank you!

### Summary
This PR moves the commands to configure the git credential helper into its own file, separate from the `git_clone.sh` script, to fix workflows functionality in SageMaker Unified Studio (SMUS) projects with third-party repositories.

### Problem
At the end of this line:
`git config --global credential.helper "!aws --profile DomainExecutionRoleCreds --region $dataZoneDomainRegion codecommit credential-helper --ignore-host-check $@"`
we pass in `$@`, which represents all command-line arguments passed to a script or command. CodeCommit requires this in the credential helper ([ref](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-https-unixes.html#setting-up-https-unixes-credential-helper)).

If the `git_clone.sh` script is invoked with a parameter, the above line results in a malformed credential helper, as the parameter passed as part of the script invocation was also being passed into the credential helper command. This was leading to errors in the SMUS workflows syncing functionality and subsequently errors on any git operation afterwards, since the credential helper was misconfigured.

### Solution
The solution for this is to move the line that takes in command-line arguments into its own script, which does not take in any parameters, so that the line can execute without the script parameters but maintain the `$@` for CodeCommit's requirement.

### Testing
I manually tested these changes in a SMUS project and validated that both the IDE and Workflows syncing functionality work as expected with third-party repositories.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
