### PR TITLE
Add download stats to staleness report

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,3 +14,4 @@ dependencies:
   - black
   - isort
   - pre-commit
+  - condastats

--- a/src/package_report.py
+++ b/src/package_report.py
@@ -71,7 +71,7 @@ def _generate_staleness_report_per_image(
 
     # Get conda download statistics for all installed packages
     # Use previous month to get full month of data
-    previous_month = (datetime.now() - relativedelta(months=1)).strftime('%Y-%m')
+    previous_month = (datetime.now() - relativedelta(months=1)).strftime("%Y-%m")
     pkg_list = list(package_versions_in_upstream.keys())
     # Suppress FutureWarning from pandas so it doesn't show in report
     with warnings.catch_warnings():
@@ -99,7 +99,12 @@ def _generate_staleness_report_per_image(
     staleness_report_rows.sort(key=lambda x: x["package"])
     print(
         create_markdown_table(
-            ["Package", "Current Version in the Distribution image", "Latest Relevant Version in " "Upstream", "Downloads (Conda, previous month)"],
+            [
+                "Package",
+                "Current Version in the Distribution image",
+                "Latest Relevant Version in " "Upstream",
+                "Downloads (Conda, previous month)",
+            ],
             staleness_report_rows,
         )
     )

--- a/src/package_report.py
+++ b/src/package_report.py
@@ -1,14 +1,14 @@
 import json
 import os
-from itertools import islice
-from datetime import datetime
-from dateutil.relativedelta import relativedelta
 import warnings
+from datetime import datetime
+from itertools import islice
 
 import boto3
 import conda.cli.python_api
 from conda.models.match_spec import MatchSpec
 from condastats.cli import overall
+from dateutil.relativedelta import relativedelta
 
 from config import _image_generator_configs
 from dependency_upgrader import _dependency_metadata

--- a/src/package_report.py
+++ b/src/package_report.py
@@ -96,7 +96,12 @@ def _generate_staleness_report_per_image(
             }
         )
 
-    staleness_report_rows.sort(key=lambda x: x["package"])
+    staleness_report_rows.sort(
+        key=lambda x: (
+            not x["package"].startswith("${\\color"),  # Stale packages at top of list
+            -x["downloads"],  # Sorted by downloads
+        )
+    )
     print(
         create_markdown_table(
             [

--- a/src/package_report.py
+++ b/src/package_report.py
@@ -3,6 +3,7 @@ import os
 from itertools import islice
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
+import warnings
 
 import boto3
 import conda.cli.python_api
@@ -72,7 +73,10 @@ def _generate_staleness_report_per_image(
     # Use previous month to get full month of data
     previous_month = (datetime.now() - relativedelta(months=1)).strftime('%Y-%m')
     pkg_list = list(package_versions_in_upstream.keys())
-    conda_download_stats = overall(pkg_list, month=previous_month)
+    # Suppress FutureWarning from pandas so it doesn't show in report
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning)
+        conda_download_stats = overall(pkg_list, month=previous_month)
 
     for package in package_versions_in_upstream:
         version_in_sagemaker_distribution = str(target_packages_match_spec_out[package].get("version")).removeprefix(

--- a/src/package_report.py
+++ b/src/package_report.py
@@ -1,10 +1,13 @@
 import json
 import os
 from itertools import islice
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
 
 import boto3
 import conda.cli.python_api
 from conda.models.match_spec import MatchSpec
+from condastats.cli import overall
 
 from config import _image_generator_configs
 from dependency_upgrader import _dependency_metadata
@@ -64,6 +67,13 @@ def _generate_staleness_report_per_image(
 ):
     print("\n# Staleness Report: " + str(version) + "(" + image_config["image_type"] + ")\n")
     staleness_report_rows = []
+
+    # Get conda download statistics for all installed packages
+    # Use previous month to get full month of data
+    previous_month = (datetime.now() - relativedelta(months=1)).strftime('%Y-%m')
+    pkg_list = list(package_versions_in_upstream.keys())
+    conda_download_stats = overall(pkg_list, month=previous_month)
+
     for package in package_versions_in_upstream:
         version_in_sagemaker_distribution = str(target_packages_match_spec_out[package].get("version")).removeprefix(
             "=="
@@ -78,11 +88,14 @@ def _generate_staleness_report_per_image(
                 "package": package_string,
                 "version_in_sagemaker_distribution": version_in_sagemaker_distribution,
                 "latest_relavant_version": package_versions_in_upstream[package],
+                "downloads": conda_download_stats[package],
             }
         )
+
+    staleness_report_rows.sort(key=lambda x: x["package"])
     print(
         create_markdown_table(
-            ["Package", "Current Version in the Distribution image", "Latest Relevant Version in " "Upstream"],
+            ["Package", "Current Version in the Distribution image", "Latest Relevant Version in " "Upstream", "Downloads (Conda, previous month)"],
             staleness_report_rows,
         )
     )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds download statistics to staleness report to gauge package popularity. Also sorting alphabetically, such that stale packages are on top and it's easier to find specific package.

Code quality check is failing for some template/test files, should fix in separate PR


---
Example staleness report
# Staleness Report: 2.4.2(gpu)                                                                                                                                                                               [11/1554]

Package | Current Version in the Distribution image | Latest Relevant Version in Upstream | Downloads (Conda, previous month)
---|---|---|---
${\color{red}boto3}$|1.36.23|1.36.26|761137
${\color{red}uvicorn}$|0.34.0|0.34.2|213369
${\color{red}langchain}$|0.3.23|0.3.24|36371
${\color{red}amazon-q-developer-jupyterlab-ext}$|3.4.7|3.4.8|3199
${\color{red}amazon-sagemaker-jupyter-ai-q-developer}$|1.0.16|1.0.17|3077
${\color{red}langchain-aws}$|0.2.10|0.2.21|1696
${\color{red}sagemaker-code-editor}$|1.4.2|1.4.3|777
pip|24.3.1|24.3.1|15208756
numpy|1.26.4|1.26.4|5734194
jinja2|3.1.6|3.1.6|3664944
scipy|1.15.2|1.15.2|3634303
conda|24.11.3|24.11.3|3604351
ipython|8.32.0|8.32.0|3146435
pandas|2.2.3|2.2.3|3128995
matplotlib-base|3.10.1|3.10.1|2518792
scikit-learn|1.5.2|1.5.2|1930584
ipywidgets|8.1.6|8.1.6|1281470
notebook|7.3.3|7.3.3|1258578
seaborn|0.13.2|0.13.2|1159322
pytorch|2.4.1|2.4.1|1013528
jupyterlab|4.3.6|4.3.6|884659
jupyter-lsp|2.2.5|2.2.5|655585
torchvision|0.19.1|0.19.1|592488
s3fs|2024.10.0|2024.10.0|276697
python-lsp-server|1.12.2|1.12.2|181744
fastapi|0.115.12|0.115.12|176913
tensorflow|2.17.0|2.17.0|152857
altair|5.5.0|5.5.0|148369
keras|3.8.0|3.8.0|135230
mlflow|2.20.4|2.20.4|89177
python-gssapi|1.9.0|1.9.0|67202
sagemaker-mlflow|0.1.0|0.1.0|41368
jupyter-server-proxy|4.4.0|4.4.0|30079
jupyterlab-git|0.50.2|0.50.2|16084
jupyter-dash|0.4.2|0.4.2|12351
pyhive|0.7.0|0.7.0|11289
supervisor|4.2.5|4.2.5|8930
py-xgboost-gpu|2.1.4|2.1.4|7015
sagemaker-python-sdk|2.240.0|2.240.0|6642
jupyterlab-lsp|5.0.3|5.0.3|5595
jupyter-ai|2.29.1|2.29.1|3729
tf-keras|2.17.0|2.17.0|3571
docker-cli|27.5.1|27.5.1|3292
jupyter-collaboration|2.1.5|2.1.5|1967
git-remote-codecommit|1.16|1.16|1820
amazon-sagemaker-jupyter-scheduler|3.1.11|3.1.11|1694
jupyter-scheduler|2.10.0|2.10.0|1426
autogluon|1.2.0|1.2.0|1231
sagemaker-studio-analytics-extension|0.1.6|0.1.6|770
amazon_sagemaker_sql_editor|0.1.16|0.1.16|762
sagemaker-kernel-wrapper|0.0.5|0.0.5|644
aws-glue-sessions|1.0.9|1.0.9|480
sagemaker-jupyterlab-extension|0.4.0|0.4.0|468
jupyter-activity-monitor-extension|0.3.1|0.3.1|453
sagemaker-jupyterlab-emr-extension|0.3.8|0.3.8|438
amazon-sagemaker-sql-magic|0.1.4|0.1.4|370
sagemaker-headless-execution-driver|0.0.13|0.0.13|353

# Staleness Report: 2.4.2(cpu)                                                                                                                                                                               [13/1619]

Package | Current Version in the Distribution image | Latest Relevant Version in Upstream | Downloads (Conda, previous month)
---|---|---|---
${\color{red}boto3}$|1.36.23|1.36.26|761137
${\color{red}uvicorn}$|0.34.0|0.34.2|213369
${\color{red}langchain}$|0.3.23|0.3.24|36371
${\color{red}amazon-q-developer-jupyterlab-ext}$|3.4.7|3.4.8|3199
${\color{red}amazon-sagemaker-jupyter-ai-q-developer}$|1.0.16|1.0.17|3077
${\color{red}langchain-aws}$|0.2.10|0.2.21|1696
${\color{red}sagemaker-code-editor}$|1.4.2|1.4.3|777
pip|24.3.1|24.3.1|15208756
numpy|1.26.4|1.26.4|5734194
jinja2|3.1.6|3.1.6|3664944
scipy|1.15.2|1.15.2|3634303
conda|24.11.3|24.11.3|3604351
ipython|8.32.0|8.32.0|3146435
pandas|2.2.3|2.2.3|3128995
matplotlib-base|3.10.1|3.10.1|2518792
scikit-learn|1.5.2|1.5.2|1930584
ipywidgets|8.1.6|8.1.6|1281470
notebook|7.3.3|7.3.3|1258578
seaborn|0.13.2|0.13.2|1159322
pytorch|2.4.1|2.4.1|1013528
jupyterlab|4.3.6|4.3.6|884659
jupyter-lsp|2.2.5|2.2.5|655585
torchvision|0.19.1|0.19.1|592488
s3fs|2024.10.0|2024.10.0|276697
python-lsp-server|1.12.2|1.12.2|181744
fastapi|0.115.12|0.115.12|176913
tensorflow|2.17.0|2.17.0|152857
altair|5.5.0|5.5.0|148369
keras|3.8.0|3.8.0|135230
mlflow|2.20.4|2.20.4|89177
python-gssapi|1.9.0|1.9.0|67202
sagemaker-mlflow|0.1.0|0.1.0|41368
jupyter-server-proxy|4.4.0|4.4.0|30079
py-xgboost-cpu|2.1.4|2.1.4|22480
jupyterlab-git|0.50.2|0.50.2|16084
jupyter-dash|0.4.2|0.4.2|12351
pyhive|0.7.0|0.7.0|11289
supervisor|4.2.5|4.2.5|8930
sagemaker-python-sdk|2.240.0|2.240.0|6642
jupyterlab-lsp|5.0.3|5.0.3|5595
jupyter-ai|2.29.1|2.29.1|3729
tf-keras|2.17.0|2.17.0|3571
docker-cli|27.5.1|27.5.1|3292
jupyter-collaboration|2.1.5|2.1.5|1967
git-remote-codecommit|1.16|1.16|1820
amazon-sagemaker-jupyter-scheduler|3.1.11|3.1.11|1694
jupyter-scheduler|2.10.0|2.10.0|1426
autogluon|1.2.0|1.2.0|1231
sagemaker-studio-analytics-extension|0.1.6|0.1.6|770
amazon_sagemaker_sql_editor|0.1.16|0.1.16|762
sagemaker-kernel-wrapper|0.0.5|0.0.5|644
aws-glue-sessions|1.0.9|1.0.9|480
sagemaker-jupyterlab-extension|0.4.0|0.4.0|468
jupyter-activity-monitor-extension|0.3.1|0.3.1|453
sagemaker-jupyterlab-emr-extension|0.3.8|0.3.8|438
amazon-sagemaker-sql-magic|0.1.4|0.1.4|370
sagemaker-headless-execution-driver|0.0.13|0.0.13|353


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
