### PR TITLE
Update sagemaker_ui_post_startup.sh to update Jupyter AI config file …

### DIFF
--- a/build_artifacts/v2/v2.6/v2.6.0/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/build_artifacts/v2/v2.6/v2.6.0/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -1,6 +1,28 @@
 #!/bin/bash
 set -eux
 
+# Override Jupyter AI config file with specific content only for 2.6
+# this is a potential workaround for Q chat issue where the chat does not
+# load since it does not pick up the latest config file
+NB_USER=sagemaker-user
+# Check if Jupyter AI config file exists, override with specific content if so only for 2.6
+# this is a potential workaround for Q chat issue
+JUPYTER_AI_CONFIG_PATH=/home/${NB_USER}/.local/share/jupyter/jupyter_ai/config.json
+JUPYTER_AI_CONFIG_CONTENT='{
+    "model_provider_id": "amazon-q:Q-Developer",
+    "embeddings_provider_id": "codesage:codesage-small",
+    "send_with_shift_enter": false,
+    "fields": {},
+    "api_keys": {},
+    "completions_model_provider_id": null,
+    "completions_fields": {},
+    "embeddings_fields": {}
+}'
+
+# Overwrite the file if it exists (or create it if it doesn't)
+echo "$JUPYTER_AI_CONFIG_CONTENT" > "$JUPYTER_AI_CONFIG_PATH"
+
+
 # Writes script status to file. This file is read by an IDE extension responsible for dispatching UI post-startup-status to the user.
 write_status_to_file() {
     local status="$1"


### PR DESCRIPTION
…for Q chat issue

In SMD 2.6, Q chat is not loading since its not picking up the latest Jupyter AI config file.  As a temp fix, changing the post start up script to update this config file with required fields so Q chat can use the updated config file.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
