### PR TITLE
Update sagemaker_ui_post_startup.sh

### DIFF
--- a/build_artifacts/v2/v2.6/v2.6.0/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/build_artifacts/v2/v2.6/v2.6.0/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -10,7 +10,7 @@ NB_USER=sagemaker-user
 JUPYTER_AI_CONFIG_PATH=/home/${NB_USER}/.local/share/jupyter/jupyter_ai/config.json
 JUPYTER_AI_CONFIG_CONTENT='{
     "model_provider_id": "amazon-q:Q-Developer",
-    "embeddings_provider_id": "codesage:codesage-small",
+    "embeddings_provider_id": null,
     "send_with_shift_enter": false,
     "fields": {},
     "api_keys": {},


### PR DESCRIPTION
In SMD 2.6, Q chat is not loading since its not picking up the latest Jupyter AI config file. As a temp fix, changing the post start up script to update this config file with required fields so Q chat can use the updated config file. We are updating the embeddings provider to be null so its backwards compatible with older SMD versions - for cases where we downgrade SMD versio

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
