### PR TITLE
Fetching the download data in report from the month before last

### DIFF
--- a/src/package_report.py
+++ b/src/package_report.py
@@ -70,8 +70,8 @@ def _generate_staleness_report_per_image(
     staleness_report_rows = []
 
     # Get conda download statistics for all installed packages
-    # Use previous month to get full month of data
-    previous_month = (datetime.now() - relativedelta(months=1)).strftime("%Y-%m")
+    # Use the month before last to get full month of data
+    previous_month = (datetime.now() - relativedelta(months=2)).strftime("%Y-%m")
     pkg_list = list(package_versions_in_upstream.keys())
     # Suppress FutureWarning from pandas so it doesn't show in report
     with warnings.catch_warnings():


### PR DESCRIPTION

*Issue #, if available:* N/A

*Description of changes:*
Fetching the download data in report from the month before last. At the beginning of the month, the conda download data for the last month may not be ready. The report generation will fail if this happens.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
