### PR TITLE
Update sagemaker-recovery-mode path

### DIFF
--- a/template/v3/Dockerfile
+++ b/template/v3/Dockerfile
@@ -102,8 +102,8 @@ RUN if [[ -z $ARG_BASED_ENV_IN_FILENAME ]] ; \
     JUPYTERLAB_VERSION=$(grep "^conda-forge::jupyterlab\[" /tmp/$ENV_IN_FILENAME) && \
     SAGEMAKER_JUPYTERLAB_VERSION=$(grep "^conda-forge::sagemaker-jupyterlab-extension" /tmp/$ENV_IN_FILENAME) && \
     echo "Installing in sagemaker-recovery-mode micromamba environment: $JUPYTERLAB_VERSION $SAGEMAKER_JUPYTERLAB_VERSION" && \
-    micromamba create -n sagemaker-recovery-mode && \
-    micromamba install -n sagemaker-recovery-mode -y $JUPYTERLAB_VERSION $SAGEMAKER_JUPYTERLAB_VERSION $SUPERVISOR_VERSION && \
+    micromamba create --prefix /opt/conda/envs/sagemaker-recovery-mode && \
+    micromamba install --prefix /opt/conda/envs/sagemaker-recovery-mode -y $JUPYTERLAB_VERSION $SAGEMAKER_JUPYTERLAB_VERSION $SUPERVISOR_VERSION && \
     micromamba clean --all --yes --force-pkgs-dirs && \
     rm -rf /tmp/*.in && \
     sudo ln -s $(which python3) /usr/bin/python && \

--- a/template/v3/dirs/usr/local/bin/entrypoint-jupyter-server
+++ b/template/v3/dirs/usr/local/bin/entrypoint-jupyter-server
@@ -9,7 +9,7 @@ eval "$(micromamba shell hook --shell=bash)"
 if [ -n "$SAGEMAKER_RECOVERY_MODE" ]; then
     export HOME=$SAGEMAKER_RECOVERY_MODE_HOME
     # Activate conda environment `sagemaker-recovery-mode`
-    micromamba activate /home/sagemaker-user/.conda/envs/sagemaker-recovery-mode
+    micromamba activate /opt/conda/envs/sagemaker-recovery-mode
 else
     # Activate conda environment 'base'
     micromamba activate base

--- a/template/v3/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v3/dirs/usr/local/bin/start-jupyter-server
@@ -6,7 +6,7 @@ eval "$(micromamba shell hook --shell=bash)"
 if [ -n "$SAGEMAKER_RECOVERY_MODE" ]; then
     export HOME=$SAGEMAKER_RECOVERY_MODE_HOME
     # Activate conda environment `sagemaker-recovery-mode`
-    micromamba activate /home/sagemaker-user/.conda/envs/sagemaker-recovery-mode
+    micromamba activate /opt/conda/envs/sagemaker-recovery-mode
 else
     # Activate conda environment 'base'
     micromamba activate base


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Updating sagemaker-recovery-mode path from  `/home/sagemaker-user/.conda/envs/sagemaker-recovery-mode` to `/opt/conda/envs/sagemaker-recovery-mode`. Seen some issues in SM AI Studio with the former path, fixed using new path. Tested in SM AI Studio.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
