### PR TITLE
Update EOS date for 2.4.x

### DIFF
--- a/support_policy.md
+++ b/support_policy.md
@@ -22,7 +22,7 @@ The tables below lists the supported SageMaker Distribution image versions and t
 | :---:         | :---:         | :---:                       |
 | 3.0.x         | public.ecr.aws/sagemaker/sagemaker-distribution:3.0-cpu  | Sep 29th, 2025  |
 | 2.6.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.6-cpu  | Oct 28th, 2025  |
-| 2.4.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.4-cpu  | Sep 7th, 2025  |
+| 2.4.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.4-cpu  | May 25th, 2025  |
 | 1.13.x        | public.ecr.aws/sagemaker/sagemaker-distribution:1.13-cpu | May 15th, 2025 |
 | 1.12.x        | public.ecr.aws/sagemaker/sagemaker-distribution:1.12-cpu | May 15th, 2025 |
 
@@ -32,7 +32,7 @@ The tables below lists the supported SageMaker Distribution image versions and t
 | :---:         | :---:         | :---:                       |
 | 3.0.x         | public.ecr.aws/sagemaker/sagemaker-distribution:3.0-gpu  | Sep 29th, 2025  |
 | 2.6.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.6-gpu  | Oct 28th, 2025  |
-| 2.4.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.4-gpu  | Sep 7th, 2025  |
+| 2.4.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.4-gpu  | May 25th, 2025  |
 | 1.13.x        | public.ecr.aws/sagemaker/sagemaker-distribution:1.13-gpu | May 15th, 2025 |
 | 1.12.x        | public.ecr.aws/sagemaker/sagemaker-distribution:1.12-gpu | May 15th, 2025 |
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update EOS date for 2.4.x to May 25th, 2025. It has CVE cannot be patched within minor version, and we've released SMD 2.6.0 patching that CVE.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
