### PR TITLE
Add test for validating anaconda channels

### DIFF
--- a/test/test_artifacts/v2/anaconda.test.Dockerfile
+++ b/test/test_artifacts/v2/anaconda.test.Dockerfile
@@ -1,0 +1,8 @@
+ARG SAGEMAKER_DISTRIBUTION_IMAGE
+FROM $SAGEMAKER_DISTRIBUTION_IMAGE
+
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+
+COPY --chown=$MAMBA_USER:$MAMBA_USER scripts/run_anaconda_tests.sh .
+RUN chmod +x run_anaconda_tests.sh
+CMD ["./run_anaconda_tests.sh"]

--- a/test/test_artifacts/v2/scripts/run_anaconda_tests.sh
+++ b/test/test_artifacts/v2/scripts/run_anaconda_tests.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Expected output
+expected_output=$'channels:\n  - conda-forge'
+
+# Actual output
+actual_micromamba=$(micromamba config list channels)
+actual_conda=$(conda config --show channels)
+
+# Compare the outputs
+if [ "$actual_micromamba" = "$expected_output" ]; then
+    echo "Micromamba Validation passed: Output matches expected format"
+    exit 0
+else
+    echo "Micromamba Validation failed: Output does not match expected format"
+    echo "Expected:"
+    echo "$expected_output"
+    echo "Actual:"
+    echo "$actual_micromamba"
+    exit 1
+fi
+
+# Compare the outputs
+if [ "$actual_conda" = "$expected_output" ]; then
+    echo "Conda Validation passed: Output matches expected format"
+    exit 0
+else
+    echo "Conda Validation failed: Output does not match expected format"
+    echo "Expected:"
+    echo "$expected_output"
+    echo "Actual:"
+    echo "$actual_conda"
+    exit 1
+fi

--- a/test/test_artifacts/v3/anaconda.test.Dockerfile
+++ b/test/test_artifacts/v3/anaconda.test.Dockerfile
@@ -1,0 +1,8 @@
+ARG SAGEMAKER_DISTRIBUTION_IMAGE
+FROM $SAGEMAKER_DISTRIBUTION_IMAGE
+
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+
+COPY --chown=$MAMBA_USER:$MAMBA_USER scripts/run_anaconda_tests.sh .
+RUN chmod +x run_anaconda_tests.sh
+CMD ["./run_anaconda_tests.sh"]

--- a/test/test_artifacts/v3/scripts/run_anaconda_tests.sh
+++ b/test/test_artifacts/v3/scripts/run_anaconda_tests.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Expected output
+expected_output=$'channels:\n  - conda-forge'
+
+# Actual output
+actual_micromamba=$(micromamba config list channels)
+actual_conda=$(conda config --show channels)
+
+# Compare the outputs
+if [ "$actual_micromamba" = "$expected_output" ]; then
+    echo "Micromamba Validation passed: Output matches expected format"
+    exit 0
+else
+    echo "Micromamba Validation failed: Output does not match expected format"
+    echo "Expected:"
+    echo "$expected_output"
+    echo "Actual:"
+    echo "$actual_micromamba"
+    exit 1
+fi
+
+# Compare the outputs
+if [ "$actual_conda" = "$expected_output" ]; then
+    echo "Conda Validation passed: Output matches expected format"
+    exit 0
+else
+    echo "Conda Validation failed: Output does not match expected format"
+    echo "Expected:"
+    echo "$expected_output"
+    echo "Actual:"
+    echo "$actual_conda"
+    exit 1
+fi

--- a/test/test_dockerfile_based_harness.py
+++ b/test/test_dockerfile_based_harness.py
@@ -18,6 +18,7 @@ _docker_client = docker.from_env()
 @pytest.mark.parametrize(
     "dockerfile_path, required_packages",
     [
+        ("anaconda.test.Dockerfile", ["conda"]),
         ("keras.test.Dockerfile", ["keras"]),
         ("autogluon.test.Dockerfile", ["autogluon"]),
         ("matplotlib.test.Dockerfile", ["matplotlib"]),
@@ -102,6 +103,7 @@ def test_dockerfiles_for_cpu(
 @pytest.mark.parametrize(
     "dockerfile_path, required_packages",
     [
+        ("anaconda.test.Dockerfile", ["conda"]),
         ("keras.test.Dockerfile", ["keras"]),
         ("autogluon.test.Dockerfile", ["autogluon"]),
         ("matplotlib.test.Dockerfile", ["matplotlib"]),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Adds a test to confirm only conda-forge channel is being used from anaconda. 

Ran test against v2 and v3:
```
======================================================================================================= PASSES =======================================================================================================
_______________________________________________________________________ test_dockerfiles_for_cpu[anaconda.test.Dockerfile-required_packages0] ________________________________________________________________________
------------------------------------------------------------------------------------------------ Captured stdout call ------------------------------------------------------------------------------------------------
Will start running test for: anaconda.test.Dockerfile against: localhost/sagemaker-distribution:2.6.0-cpu
Built a test image: sha256:c0f9aa1bcc6213734374466b0a66f87d51f78a37e4c1a698d4e84c02c315f954, will now execute its default CMD.
_______________________________________________________________________ test_dockerfiles_for_gpu[anaconda.test.Dockerfile-required_packages0] ________________________________________________________________________
------------------------------------------------------------------------------------------------ Captured stdout call ------------------------------------------------------------------------------------------------
Will start running test for: anaconda.test.Dockerfile against: localhost/sagemaker-distribution:2.6.0-gpu
Built a test image: sha256:9f30821c395f7ca7fc41e433d0956712b01c99bfb5dbdc27264d6ff0d016aacc, will now execute its default CMD.
============================================================================================== short test summary info ===============================================================================================
PASSED test/test_dockerfile_based_harness.py::test_dockerfiles_for_cpu[anaconda.test.Dockerfile-required_packages0]
PASSED test/test_dockerfile_based_harness.py::test_dockerfiles_for_gpu[anaconda.test.Dockerfile-required_packages0]

======================================================================================================= PASSES =======================================================================================================
_______________________________________________________________________ test_dockerfiles_for_cpu[anaconda.test.Dockerfile-required_packages0] ________________________________________________________________________
------------------------------------------------------------------------------------------------ Captured stdout call ------------------------------------------------------------------------------------------------
Will start running test for: anaconda.test.Dockerfile against: localhost/sagemaker-distribution:3.1.0-cpu
Built a test image: sha256:e8af344373ffd86e6012df3998ca3b019fa16fd8df755bfefeb1c5828f8e4401, will now execute its default CMD.
_______________________________________________________________________ test_dockerfiles_for_gpu[anaconda.test.Dockerfile-required_packages0] ________________________________________________________________________
------------------------------------------------------------------------------------------------ Captured stdout call ------------------------------------------------------------------------------------------------
Will start running test for: anaconda.test.Dockerfile against: localhost/sagemaker-distribution:3.1.0-gpu
Built a test image: sha256:5f3b172263ca2fa21478771c13ee9f0f84ee6aa42a327458ae34579445566506, will now execute its default CMD.
============================================================================================== short test summary info ===============================================================================================
PASSED test/test_dockerfile_based_harness.py::test_dockerfiles_for_cpu[anaconda.test.Dockerfile-required_packages0]
PASSED test/test_dockerfile_based_harness.py::test_dockerfiles_for_gpu[anaconda.test.Dockerfile-required_packages0]
```

Also tagged a older v1 image (1.0.0) as v2 image and ran test, validated it fails
```
============================================================================================== short test summary info ===============================================================================================
FAILED test/test_dockerfile_based_harness.py::test_dockerfiles_for_cpu[anaconda.test.Dockerfile-required_packages0] - assert 1 == 0
FAILED test/test_dockerfile_based_harness.py::test_dockerfiles_for_gpu[anaconda.test.Dockerfile-required_packages0] - assert 1 == 0
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
