### PR TITLE
Update micromamba version in image build workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -40,7 +40,7 @@ jobs:
       target_version: ${{ steps.calc_target.outputs.target_version }}
     steps:
       - uses: actions/checkout@v4
-      - uses: mamba-org/setup-micromamba@v1
+      - uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: ./environment.lock
           environment-name: sagemaker-distribution


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Started seeing micromamba fail on v1 when testing nightly builds, so updated in all workflows in https://github.com/aws/sagemaker-distribution/commit/372f050cdd27c8fd760df098ae50ec6c3881b1e4. But, realized the file didn't save with this update in image-build so this workflow was missed, leading to failure like https://github.com/aws/sagemaker-distribution/actions/runs/15174979229/job/42673390135. Updating this workflow as well to unblock


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
