### PR TITLE
Set fetch-depth to get all branches in image build

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -40,6 +40,8 @@ jobs:
       target_version: ${{ steps.calc_target.outputs.target_version }}
     steps:
       - uses: actions/checkout@v4
+        with:
+            fetch-depth: 0
       - uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: ./environment.lock


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* We need to set fetch-depth to get all branches; in 2.6.1 build, it found existing branch, but then failed to check it out. https://github.com/actions/checkout?tab=readme-ov-file#fetch-all-history-for-all-tags-and-branches

```
 277453eef5b4476844bec5e0894ffa73fc9165e8	refs/heads/release-2.6.1
Branch exists, merging latest changes in
error: pathspec 'release-2.6.1' did not match any file(s) known to git
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
