### PR TITLE
Updating post startup script for non-git storage feature

### DIFF
--- a/template/v2/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/template/v2/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -79,9 +79,6 @@ dataZoneDomainRegion=$(jq -r '.AdditionalMetadata.DataZoneDomainRegion' < $sourc
 
 set +e
 
-# Creating a directory where the repository will be cloned
-mkdir -p $HOME/src
-
 # Remove the ~/.aws/config file to start clean when space restart
 rm -f /home/sagemaker-user/.aws/config
 echo "Successfully removed the ~/.aws/config file"
@@ -128,9 +125,6 @@ else
         echo "Successfully configured DomainExecutionRoleCreds profile"
 fi
 
-echo "Starting execution of Git Cloning script"
-bash /etc/sagemaker-ui/git_clone.sh
-
 # Run AWS CLI command to get the username from DataZone User Profile.
 if [ ! -z "$dataZoneEndPoint" ]; then
     response=$( aws datazone get-user-profile --endpoint-url "$dataZoneEndPoint" --domain-identifier "$dataZoneDomainId" --user-identifier "$dataZoneUserId" --region "$dataZoneDomainRegion" )
@@ -164,9 +158,34 @@ case "$auth_mode" in
         ;;
 esac
 
-# Setting up the Git identity for the user .
-git config --global user.email "$email"
-git config --global user.name "$username"
+# Checks if the project is using Git or Non-Git storage
+is_non_git_storage() {
+  getProjectDefaultEnvResponse=$(sagemaker-studio project get-project-default-environment --domain-id "$dataZoneDomainId" --project-id "$dataZoneProjectId" --profile DomainExecutionRoleCreds)
+  gitConnectionArn=$(echo "$getProjectDefaultEnvResponse" | jq -r '.provisionedResources[] | select(.name=="gitConnectionArn") | .value')
+  codeRepositoryName=$(echo "$getProjectDefaultEnvResponse" | jq -r '.provisionedResources[] | select(.name=="codeRepositoryName") | .value')
+
+  if [ -z "$gitConnectionArn" ] && [ -z "$codeRepositoryName" ]; then
+      return 0
+  else
+      return 1
+  fi
+}
+
+echo "Checking Project Storage Type"
+
+if ! is_non_git_storage; then
+  # Creating a directory where the repository will be cloned
+  mkdir -p "$HOME/src"
+
+  echo "Starting execution of Git Cloning script"
+  bash /etc/sagemaker-ui/git_clone.sh
+
+  # Setting up the Git identity for the user .
+  git config --global user.email "$email"
+  git config --global user.name "$username"
+else
+  echo "Project is using Non-Git storage, skipping git repository setup and ~/src dir creation"
+fi
 
 # MLFlow tracking server uses the LOGNAME environment variable to track identity. Set the LOGNAME to the username of the user associated with the space
 export LOGNAME=$username


### PR DESCRIPTION
## Description
This change modifies the post startup script to not initialize a Git repository and skip creating the `~/src` directory if the project uses the non-git storage feature. Shared storage for the project will be provided via a S3 bucket mounted on the space. 

## Type of Change
- [ ] Image update - Bug fix
- [x] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ ] Yes (Critical bug fix or security update)
- [x] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
N/A - Patch is not required

## How Has This Been Tested?
Tested the changes in 3 different projects by running the post startup script from a terminal window

1) CodeConnections (3P Git)
- Verified that src dir is created and git repository is initialized.

2) CodeCommit (Current default)
- Verified that src dir is created and git repository is initialized

3) Non git storage project
- Creating a non-git storage project with spaces is currently blocked, so this scenario was verified by hardcoding the `get-project-default-environment` response to return empty string for `gitConnectionArn` and `codeRepositoryName`
- Verified that src dir is not created and git repository is not initialized. 

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):
N/A

## Related Issues
N/A
## Additional Notes
N/A
