### PR TITLE
Remove Jupyter_AI config override from post script

### DIFF
--- a/template/v2/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/template/v2/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -1,30 +1,6 @@
 #!/bin/bash
 set -eux
 
-# Only run the following commands if SAGEMAKER_APP_TYPE_LOWERCASE is jupyterlab
-if [ "${SAGEMAKER_APP_TYPE_LOWERCASE}" = "jupyterlab" ]; then
-    # Override Jupyter AI config file with specific content only for 2.6
-    # this is a potential workaround for Q chat issue where the chat does not
-    # load since it does not pick up the latest config file
-    NB_USER=sagemaker-user
-    # Check if Jupyter AI config file exists, override with specific content if so only for 2.6
-    # this is a potential workaround for Q chat issue
-    JUPYTER_AI_CONFIG_PATH=/home/${NB_USER}/.local/share/jupyter/jupyter_ai/config.json
-    JUPYTER_AI_CONFIG_CONTENT='{
-        "model_provider_id": "amazon-q:Q-Developer",
-        "embeddings_provider_id": null,
-        "send_with_shift_enter": false,
-        "fields": {},
-        "api_keys": {},
-        "completions_model_provider_id": null,
-        "completions_fields": {},
-        "embeddings_fields": {}
-    }'
-
-    # Overwrite the file if it exists (or create it if it doesn't)
-    echo "$JUPYTER_AI_CONFIG_CONTENT" > "$JUPYTER_AI_CONFIG_PATH"
-fi
-
 # Writes script status to file. This file is read by an IDE extension responsible for dispatching UI post-startup-status to the user.
 write_status_to_file() {
     local status="$1"

--- a/template/v3/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/template/v3/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -1,30 +1,6 @@
 #!/bin/bash
 set -eux
 
-# Only run the following commands if SAGEMAKER_APP_TYPE_LOWERCASE is jupyterlab
-if [ "${SAGEMAKER_APP_TYPE_LOWERCASE}" = "jupyterlab" ]; then
-    # Override Jupyter AI config file with specific content only for 2.6
-    # this is a potential workaround for Q chat issue where the chat does not
-    # load since it does not pick up the latest config file
-    NB_USER=sagemaker-user
-    # Check if Jupyter AI config file exists, override with specific content if so only for 2.6
-    # this is a potential workaround for Q chat issue
-    JUPYTER_AI_CONFIG_PATH=/home/${NB_USER}/.local/share/jupyter/jupyter_ai/config.json
-    JUPYTER_AI_CONFIG_CONTENT='{
-        "model_provider_id": "amazon-q:Q-Developer",
-        "embeddings_provider_id": null,
-        "send_with_shift_enter": false,
-        "fields": {},
-        "api_keys": {},
-        "completions_model_provider_id": null,
-        "completions_fields": {},
-        "embeddings_fields": {}
-    }'
-
-    # Overwrite the file if it exists (or create it if it doesn't)
-    echo "$JUPYTER_AI_CONFIG_CONTENT" > "$JUPYTER_AI_CONFIG_PATH"
-fi
-
 # Writes script status to file. This file is read by an IDE extension responsible for dispatching UI post-startup-status to the user.
 write_status_to_file() {
     local status="$1"


### PR DESCRIPTION
## Description
The long term fix has been addressed in backend so removing this override logic from post startup script to enable the jupyter_ai slash commends

## Type of Change
- Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
The newest jupyter_ai extension has been included in the current baking patch version and we observed the issue which config file is overridden. So yes this has to be included in. 

## How Has This Been Tested?
Triggered the script manually and the config file wasn't changed

## Checklist:
- My code follows the style guidelines of this project
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
[Link any related issues here]

## Additional Notes
[Any additional information that might be helpful for reviewers]
