### PR TITLE
Remove notebook export options that are not supported by SMD

### DIFF
--- a/template/v2/dirs/etc/sagemaker-ui/jupyter/server/jupyter_server_config.py
+++ b/template/v2/dirs/etc/sagemaker-ui/jupyter/server/jupyter_server_config.py
@@ -17,6 +17,12 @@ c.FileContentsManager.always_delete_dir = True
 # Related documentation: https://jupyterlab.readthedocs.io/en/stable/user/files.html#displaying-hidden-files
 c.ContentsManager.allow_hidden = True
 
+# Disable exporters that are not supported by the sagemaker distribution
+c.PDFExporter.enabled = False
+c.WebPDFExporter.enabled = False
+c.QtPNGExporter.enabled = False
+c.QtPDFExporter.enabled = False
+
 # This will set the LanguageServerManager.extra_node_roots setting if amazon_sagemaker_sql_editor exists in the
 # environment. Ignore otherwise, don't fail the JL server start
 # Related documentation: https://jupyterlab-lsp.readthedocs.io/en/v3.4.0/Configuring.html

--- a/template/v3/dirs/etc/jupyter/jupyter_server_config.py
+++ b/template/v3/dirs/etc/jupyter/jupyter_server_config.py
@@ -15,6 +15,12 @@ c.FileContentsManager.always_delete_dir = True
 # Related documentation: https://jupyterlab.readthedocs.io/en/stable/user/files.html#displaying-hidden-files
 c.ContentsManager.allow_hidden = True
 
+# Disable exporters that are not supported by the sagemaker distribution
+c.PDFExporter.enabled = False
+c.WebPDFExporter.enabled = False
+c.QtPNGExporter.enabled = False
+c.QtPDFExporter.enabled = False
+
 # This will set the LanguageServerManager.extra_node_roots setting if amazon_sagemaker_sql_editor exists in the
 # environment. Ignore otherwise, don't fail the JL server start
 # Related documentation: https://jupyterlab-lsp.readthedocs.io/en/v3.4.0/Configuring.html


### PR DESCRIPTION
## Description

PDF, webPDF, qtpng, and qtpdf exports fail in SageMaker Unified Studio and SageMaker Studio JL, requiring extra configuration and package installations to function. Many of these dependencies are very large, so they are not being considered to be included in the SageMaker Distribution at this time. This PR disables these exporters.

## Type of Change
- [x] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ ] Yes (Critical bug fix or security update)
- [x] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]

## How Has This Been Tested?

Update jupyter_server_config.py in local workspace and restart server; confirmed failing options no longer appear.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

![Screenshot 2025-06-11 at 2 47 36 PM](https://github.com/user-attachments/assets/64fad8de-4b81-4790-9054-178a4a2c6b1e)

## Related Issues
Internal Asana tracking

## Additional Notes
None
