### PR TITLE
Add region configuration to default profile - future patch

### DIFF
--- a/build_artifacts/v2/v2.7/v2.7.0/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/build_artifacts/v2/v2.7/v2.7.0/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -89,6 +89,10 @@ echo "Successfully removed the ~/.aws/config file"
 aws configure set credential_source EcsContainer
 echo "Successfully configured default profile"
 
+# Add region configuration using REGION_NAME environment variable
+aws configure set region "${REGION_NAME}"
+echo "Successfully configured region to ${REGION_NAME}"
+
 # add SparkMonitor and Connection Magic entrypoint
 NB_USER=sagemaker-user
 

--- a/build_artifacts/v3/v3.2/v3.2.0/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/build_artifacts/v3/v3.2/v3.2.0/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -89,6 +89,10 @@ echo "Successfully removed the ~/.aws/config file"
 aws configure set credential_source EcsContainer
 echo "Successfully configured default profile"
 
+# Add region configuration using REGION_NAME environment variable
+aws configure set region "${REGION_NAME}"
+echo "Successfully configured region to ${REGION_NAME}"
+
 # add SparkMonitor and Connection Magic entrypoint
 NB_USER=sagemaker-user
 


### PR DESCRIPTION
## Description

**This change is already added to v2 and v3 templates https://github.com/aws/sagemaker-distribution/pull/687**

This change is to resolve the issue that AWS Toolkit is always configured to us-east-1.

If the profile that the AWS Toolkit is configured with contains a region key, its value will be used to determine the partition used by these credentials. When a region is not found, the profile uses the region us-east-1, see [Connecting to AWS from AWS Toolkit](https://github.com/aws/aws-toolkit-vscode/blob/master/docs/connecting-to-aws.md). As the default profile in SMUS CodeEditor space does not have a region, so the AWS Toolkit is initialized with us-east-1.

To resolve this issue, we need to specify the Tooling region in the default profile. The Tooling Region is defined in the space environment when the app is launched, see [code](https://code.amazon.com/packages/LooseLeafHostAgent/blobs/67cca5f444d65ff4bc81d1c404c4f11c2672419c/--/tasks/app/launch_app.go#L452-L455).

For more detail please see [this doc](https://quip-amazon.com/xX1AADT12vMk/VS-Code-in-SMUS-AWS-Toolkits-Issue).
## Type of Change
- [ ] Image update - Bug fix
- [x] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ ] Yes (Critical bug fix or security update)
- [x] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
N/A

## How Has This Been Tested?
In a test project:

- Updated /etc/sagemaker-ui/sagemaker_ui_post_startup.sh
- `source /etc/sagemaker-ui/sagemaker_ui_post_startup.sh`
- Reopen the CodeEditor space
- Verified that the Tooling region is added to AWS Toolbox Explorer
- verify the python SDK commands in getting_started.ipynb works
this process is done for cross region as well. 

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

Supporting screenshots are provided https://github.com/aws/sagemaker-distribution/pull/687
