### PR TITLE
Writing SMUS_PROJECT_DIR to a JSON file to be accessed by JupyterLab Extensions

### DIFF
--- a/template/v2/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/template/v2/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -172,6 +172,11 @@ else
   echo readonly SMUS_PROJECT_DIR >> ~/.bashrc
 fi
 
+# Write SMUS_PROJECT_DIR to a JSON file to be accessed by JupyterLab Extensions
+jq -n \
+  --arg smusProjectDirectory "$SMUS_PROJECT_DIR" \
+  '{ smusProjectDirectory: $smusProjectDirectory }' > $HOME/.config/smus-storage-metadata.json
+
 if [ $is_s3_storage_flag -ne 0 ]; then
   # Creating a directory where the repository will be cloned
   mkdir -p "$HOME/src"

--- a/template/v3/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/template/v3/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -172,6 +172,11 @@ else
   echo readonly SMUS_PROJECT_DIR >> ~/.bashrc
 fi
 
+# Write SMUS_PROJECT_DIR to a JSON file to be accessed by JupyterLab Extensions
+jq -n \
+  --arg smusProjectDirectory "$SMUS_PROJECT_DIR" \
+  '{ smusProjectDirectory: $smusProjectDirectory }' > $HOME/.config/smus-storage-metadata.json
+
 if [ $is_s3_storage_flag -ne 0 ]; then
   # Creating a directory where the repository will be cloned
   mkdir -p "$HOME/src"


### PR DESCRIPTION
In #719, SMUS_PROJECT_DIR was exported to be used as the source of truth for where the projects contents would be available, however since the post startup script happens after JupyterLab is started, extensions in JL are unable to pick up this var. This change writes the value of SMUS_PROJECT_DIR to a JSON file in 
`$HOME/.config/smus-storage-metadata.json`

## Description
[Provide a brief description of the changes]

## Type of Change
- [x] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ ] Yes (Critical bug fix or security update)
- [x] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
N/A - does not need to be patched into previous versions

## How Has This Been Tested?
Ran post startup script in a sagemaker space. Verified that file was created in the correct location with the correct content. See screenshots below. 

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):
<img width="1015" alt="Screenshot 2025-06-25 at 7 59 19 PM" src="https://github.com/user-attachments/assets/29c7457f-e85e-489d-a23d-c69dd0b45d4f" />
<img width="754" alt="Screenshot 2025-06-25 at 8 06 35 PM" src="https://github.com/user-attachments/assets/986b0b05-3304-430e-8da6-1e001fde1856" />

## Related Issues
NA

## Additional Notes
NA
