### PR TITLE
Add IS_GIT_PROJECT variable and write to smus-storage-metadata.json

### DIFF
--- a/template/v2/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/template/v2/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -158,9 +158,11 @@ is_s3_storage
 is_s3_storage_flag=$?  # 0 if S3 storage, 1 if Git
 
 if [ "$is_s3_storage_flag" -eq 0 ]; then
+    export IS_GIT_PROJECT=false
     export SMUS_PROJECT_DIR="$HOME/shared"
     echo "Project is using S3 storage, project directory set to: $SMUS_PROJECT_DIR"
 else
+    export IS_GIT_PROJECT=true
     export SMUS_PROJECT_DIR="$HOME/src"
     echo "Project is using Git storage, project directory set to: $SMUS_PROJECT_DIR"
 fi
@@ -173,9 +175,14 @@ else
 fi
 
 # Write SMUS_PROJECT_DIR to a JSON file to be accessed by JupyterLab Extensions
+mkdir -p "$HOME/.config"  # Create config directory if it doesn't exist
 jq -n \
   --arg smusProjectDirectory "$SMUS_PROJECT_DIR" \
-  '{ smusProjectDirectory: $smusProjectDirectory }' > $HOME/.config/smus-storage-metadata.json
+  --arg isGitProject "$IS_GIT_PROJECT" \
+  '{ 
+    smusProjectDirectory: $smusProjectDirectory,
+    isGitProject: ($isGitProject == "true")
+  }' > "$HOME/.config/smus-storage-metadata.json"
 
 if [ $is_s3_storage_flag -ne 0 ]; then
   # Creating a directory where the repository will be cloned

--- a/template/v3/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/template/v3/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -158,9 +158,11 @@ is_s3_storage
 is_s3_storage_flag=$?  # 0 if S3 storage, 1 if Git
 
 if [ "$is_s3_storage_flag" -eq 0 ]; then
+    export IS_GIT_PROJECT=false
     export SMUS_PROJECT_DIR="$HOME/shared"
     echo "Project is using S3 storage, project directory set to: $SMUS_PROJECT_DIR"
 else
+    export IS_GIT_PROJECT=true
     export SMUS_PROJECT_DIR="$HOME/src"
     echo "Project is using Git storage, project directory set to: $SMUS_PROJECT_DIR"
 fi
@@ -173,9 +175,14 @@ else
 fi
 
 # Write SMUS_PROJECT_DIR to a JSON file to be accessed by JupyterLab Extensions
+mkdir -p "$HOME/.config"  # Create config directory if it doesn't exist
 jq -n \
   --arg smusProjectDirectory "$SMUS_PROJECT_DIR" \
-  '{ smusProjectDirectory: $smusProjectDirectory }' > $HOME/.config/smus-storage-metadata.json
+  --arg isGitProject "$IS_GIT_PROJECT" \
+  '{ 
+    smusProjectDirectory: $smusProjectDirectory,
+    isGitProject: ($isGitProject == "true")
+  }' > "$HOME/.config/smus-storage-metadata.json"
 
 if [ $is_s3_storage_flag -ne 0 ]; then
   # Creating a directory where the repository will be cloned


### PR DESCRIPTION
## Description
followup on https://github.com/aws/sagemaker-distribution/pull/729/files, also add the IS_GIT_PROJECT flag to env variable and write to .config/smus-storage-metadata.json  so that it can be used in Jupyterlab extensions

## Type of Change
- [ ] Image update - Bug fix
- [x] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ ] Yes (Critical bug fix or security update)
- [x] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]

## How Has This Been Tested?
tested by running the touched lines in Gamma jupyterlab: 
```
sagemaker-user@default:~/.config$ is_s3_storage_flag=1
sagemaker-user@default:~/.config$ if [ "$is_s3_storage_flag" -eq 0 ]; then     export IS_GIT_PROJECT=false;     export SMUS_PROJECT_DIR="$HOME/shared";     echo "Project is using S3 storage, project directory set to: $SMUS_PROJECT_DIR"; else     export IS_GIT_PROJECT=true;     export SMUS_PROJECT_DIR="$HOME/src";     echo "Project is using Git storage, project directory set to: $SMUS_PROJECT_DIR"; fi
Project is using Git storage, project directory set to: /home/sagemaker-user/src
sagemaker-user@default:~/.config$ if grep -q "^SMUS_PROJECT_DIR=" ~/.bashrc; then
  echo "SMUS_PROJECT_DIR is defined in the env"
else
  echo SMUS_PROJECT_DIR="$SMUS_PROJECT_DIR" >> ~/.bashrc
  echo readonly SMUS_PROJECT_DIR >> ~/.bashrc
fi
sagemaker-user@default:~/.config$ mkdir -p "$HOME/.config"  # Create config directory if it doesn't exist
jq -n \
  --arg smusProjectDirectory "$SMUS_PROJECT_DIR" \
  --arg isGitProject "$IS_GIT_PROJECT" \
  '{ 
    smusProjectDirectory: $smusProjectDirectory,
    isGitProject: ($isGitProject == "true")
  }' > "$HOME/.config/smus-storage-metadata.json"
sagemaker-user@default:~/.config$ cat smus-storage-metadata.json ^C
sagemaker-user@default:~/.config$ cd ..
sagemaker-user@default:~$ cat .config/smus-storage-metadata.json | jq
{
  "smusProjectDirectory": "/home/sagemaker-user/src",
  "isGitProject": true
}
```

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
[Link any related issues here]

## Additional Notes
[Any additional information that might be helpful for reviewers]
