### PR TITLE
feat: Add recovery mode support for Unified Studio

### DIFF
--- a/template/v2/dirs/usr/local/bin/entrypoint-sagemaker-ui-jupyter-server
+++ b/template/v2/dirs/usr/local/bin/entrypoint-sagemaker-ui-jupyter-server
@@ -9,8 +9,15 @@ eval "$(micromamba shell hook --shell=bash)"
 # apply patches for SMUS
 /etc/patches/apply_patches.sh smus && sudo rm -rf /etc/patches
 
-# Activate conda environment 'base', where supervisord is installed
-micromamba activate base
+# Activate conda environment depending on if we are in Recovery or Standard mode. 
+if [ -n "$SAGEMAKER_RECOVERY_MODE" ]; then
+    export HOME=$SAGEMAKER_RECOVERY_MODE_HOME
+    # Activate conda environment `sagemaker-recovery-mode`
+    micromamba activate sagemaker-recovery-mode
+else
+    # Activate conda environment 'base', where supervisord is installed
+    micromamba activate base
+fi
 
 export SAGEMAKER_APP_TYPE_LOWERCASE=$(echo $SAGEMAKER_APP_TYPE | tr '[:upper:]' '[:lower:]')
 export SERVICE_NAME='SageMakerUnifiedStudio'

--- a/template/v2/dirs/usr/local/bin/start-sagemaker-ui-jupyter-server
+++ b/template/v2/dirs/usr/local/bin/start-sagemaker-ui-jupyter-server
@@ -3,8 +3,14 @@ set -e
 
 eval "$(micromamba shell hook --shell=bash)"
 
-# Activate conda environment 'base', which is the default environment for Cosmos
-micromamba activate base
+# Activate conda environment depending on if we are in Recovery or Standard mode. 
+if [ -n "$SAGEMAKER_RECOVERY_MODE" ]; then
+    # Activate conda environment `sagemaker-recovery-mode`
+    micromamba activate sagemaker-recovery-mode
+else
+    # Activate conda environment 'base' which is the default for Cosmos
+    micromamba activate base
+fi
 
 sudo cp -r /etc/sagemaker-ui/kernels/. /opt/conda/share/jupyter/kernels/
 sudo cp /etc/sagemaker-ui/jupyter/server/jupyter_server_config.py /opt/conda/etc/jupyter/
@@ -28,10 +34,19 @@ if [[ $(jupyter kernelspec list | grep glue_pyspark) ]]; then
   jupyter-kernelspec remove -f -y glue_pyspark
 fi
 
-jupyter lab --ip 0.0.0.0 --port 8888 \
-  --ServerApp.base_url="/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
-  --ServerApp.token='' \
-  --ServerApp.allow_origin='*' \
-  --SchedulerApp.db_url='sqlite:////tmp/.jupyter_scheduler_do_not_delete.sqlite' \
-  --collaborative \
-  --ServerApp.identity_provider_class='sagemaker_jupyter_server_extension.identity.SageMakerIdentityProvider' 
+if [ -n "$SAGEMAKER_RECOVERY_MODE" ]; then
+  # Disabling collaboration and identity_provider_class flags for recovery mode
+  jupyter lab --ip 0.0.0.0 --port 8888 \
+    --ServerApp.base_url="/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
+    --ServerApp.token='' \
+    --ServerApp.allow_origin='*' \
+    --SchedulerApp.db_url='sqlite:////tmp/.jupyter_scheduler_do_not_delete.sqlite'
+else 
+  jupyter lab --ip 0.0.0.0 --port 8888 \
+    --ServerApp.base_url="/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
+    --ServerApp.token='' \
+    --ServerApp.allow_origin='*' \
+    --SchedulerApp.db_url='sqlite:////tmp/.jupyter_scheduler_do_not_delete.sqlite' \
+    --collaborative \
+    --ServerApp.identity_provider_class='sagemaker_jupyter_server_extension.identity.SageMakerIdentityProvider' 
+fi 

--- a/template/v3/dirs/usr/local/bin/entrypoint-sagemaker-ui-jupyter-server
+++ b/template/v3/dirs/usr/local/bin/entrypoint-sagemaker-ui-jupyter-server
@@ -9,8 +9,15 @@ eval "$(micromamba shell hook --shell=bash)"
 # apply patches for SMUS
 /etc/patches/apply_patches.sh smus && sudo rm -rf /etc/patches
 
-# Activate conda environment 'base', where supervisord is installed
-micromamba activate base
+# Activate conda environment depending on if we are in Recovery or Standard mode. 
+if [ -n "$SAGEMAKER_RECOVERY_MODE" ]; then
+    export HOME=$SAGEMAKER_RECOVERY_MODE_HOME
+    # Activate conda environment `sagemaker-recovery-mode`
+    micromamba activate sagemaker-recovery-mode
+else
+    # Activate conda environment 'base', where supervisord is installed
+    micromamba activate base
+fi
 
 export SAGEMAKER_APP_TYPE_LOWERCASE=$(echo $SAGEMAKER_APP_TYPE | tr '[:upper:]' '[:lower:]')
 export SERVICE_NAME='SageMakerUnifiedStudio'

--- a/template/v3/dirs/usr/local/bin/start-sagemaker-ui-jupyter-server
+++ b/template/v3/dirs/usr/local/bin/start-sagemaker-ui-jupyter-server
@@ -3,8 +3,14 @@ set -e
 
 eval "$(micromamba shell hook --shell=bash)"
 
-# Activate conda environment 'base', which is the default environment for Cosmos
-micromamba activate base
+# Activate conda environment depending on if we are in Recovery or Standard mode. 
+if [ -n "$SAGEMAKER_RECOVERY_MODE" ]; then
+    # Activate conda environment `sagemaker-recovery-mode`
+    micromamba activate sagemaker-recovery-mode
+else
+    # Activate conda environment 'base' which is the default for Cosmos
+    micromamba activate base
+fi
 
 sudo cp -r /etc/sagemaker-ui/kernels/. /opt/conda/share/jupyter/kernels/
 sudo cp /etc/sagemaker-ui/jupyter/server/jupyter_server_config.py /opt/conda/etc/jupyter/
@@ -28,10 +34,19 @@ if [[ $(jupyter kernelspec list | grep glue_pyspark) ]]; then
   jupyter-kernelspec remove -f -y glue_pyspark
 fi
 
-jupyter lab --ip 0.0.0.0 --port 8888 \
-  --ServerApp.base_url="/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
-  --ServerApp.token='' \
-  --ServerApp.allow_origin='*' \
-  --SchedulerApp.db_url='sqlite:////tmp/.jupyter_scheduler_do_not_delete.sqlite' \
-  --collaborative \
-  --ServerApp.identity_provider_class='sagemaker_jupyter_server_extension.identity.SageMakerIdentityProvider' 
+if [ -n "$SAGEMAKER_RECOVERY_MODE" ]; then
+  # Disabling collaboration and identity_provider_class flags for recovery mode
+  jupyter lab --ip 0.0.0.0 --port 8888 \
+    --ServerApp.base_url="/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
+    --ServerApp.token='' \
+    --ServerApp.allow_origin='*' \
+    --SchedulerApp.db_url='sqlite:////tmp/.jupyter_scheduler_do_not_delete.sqlite'
+else 
+  jupyter lab --ip 0.0.0.0 --port 8888 \
+    --ServerApp.base_url="/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
+    --ServerApp.token='' \
+    --ServerApp.allow_origin='*' \
+    --SchedulerApp.db_url='sqlite:////tmp/.jupyter_scheduler_do_not_delete.sqlite' \
+    --collaborative \
+    --ServerApp.identity_provider_class='sagemaker_jupyter_server_extension.identity.SageMakerIdentityProvider' 
+fi 


### PR DESCRIPTION
## Description
In both version 2 and 3
In Entrypoint scripts:
-Created a new folder which will be used as home directory in recovery mode
-Added if condition to start switch micromamba environment based on recovery mode

In Start scripts:
-Added if condition to start switch micromamba environment based on recovery mode
-Added if condition to disable collaboration and identity_provider_class flags to be able to provide minimal environment for recovery mode

## Type of Change
- Image update - New feature

## Release Information
- New feature

## How Has This Been Tested?
I ran the script using a custom image, passing in the recovery mode parameter set to both true and false via the API call. I then tested the script on the SMUS platform and observed that Jupyterlab started as intended in both scenarios

## Test Screenshots (if applicable):
<img width="395" alt="Screenshot 2025-06-25 at 1 53 31 PM" src="https://github.com/user-attachments/assets/f5f2cf29-aa23-4208-b79c-6998cd22229b" />

![image](https://github.com/user-attachments/assets/d9cd4206-0f77-469a-96bc-e5d685b8b950)



