### PR TITLE
Update network_validation script to flag failing calls due to endpoint URL as unreachable

### DIFF
--- a/template/v2/dirs/etc/sagemaker-ui/network_validation.sh
+++ b/template/v2/dirs/etc/sagemaker-ui/network_validation.sh
@@ -126,14 +126,18 @@ temp_dir=$(mktemp -d)
 # Launch all service API checks in parallel background jobs
 for service in "${!SERVICE_COMMANDS[@]}"; do
   {
-    # Run command with timeout, discard stdout/stderr
-    if timeout "${api_time_out_limit}s" bash -c "${SERVICE_COMMANDS[$service]}" > /dev/null 2>&1; then
+    output_file="$temp_dir/${service}_output"
+
+    # Run command with timeout
+    if timeout "${api_time_out_limit}s" bash -c "${SERVICE_COMMANDS[$service]}" > "$output_file" 2>&1; then
       # Success: write OK to temp file
       echo "OK" > "$temp_dir/$service"
     else
       # Get exit code to differentiate timeout or other errors
       exit_code=$?
-      if [ "$exit_code" -eq 124 ]; then
+      if grep -q "Could not connect to the endpoint URL" "$output_file"; then
+        echo "UNREACHABLE" > "$temp_dir/$service"
+      elif [ "$exit_code" -eq 124 ]; then
         # Timeout exit code
         echo "TIMEOUT" > "$temp_dir/$service"
       else
@@ -155,10 +159,13 @@ for service in "${!SERVICE_COMMANDS[@]}"; do
     if [[ "$result" == "TIMEOUT" ]]; then
       echo "$service API did NOT resolve within ${api_time_out_limit}s. Marking as unreachable."
       unreachable_services+=("$service")
+    elif [[ "$result" == "UNREACHABLE" ]]; then
+      echo "$service API failed to connect to the endpoint. Marking as unreachable."
+      unreachable_services+=("$service")
     elif [[ "$result" == "OK" ]]; then
       echo "$service API is reachable."
     else
-      echo "$service API returned an error (but not a timeout). Ignored for network check."
+      echo "$service API returned an error (but not a timeout or endpoint reachability failure). Ignored for network check."
     fi
   else
     echo "$service check did not produce a result file. Skipping."

--- a/template/v2/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/template/v2/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -241,7 +241,13 @@ if bash /etc/sagemaker-ui/network_validation.sh "$is_s3_storage_flag" "$network_
     # Read unreachable services from JSON file
     failed_services=$(jq -r '.UnreachableServices // empty' "$network_validation_file" || echo "")
     if [[ -n "$failed_services" ]]; then
-        error_message="$failed_services are unreachable. Please contact your admin."
+        # Count number of services by splitting on comma
+        IFS=',' read -ra failed_array <<< "$failed_services"
+        count=${#failed_array[@]}
+        verb="are"
+        [[ "$count" -eq 1 ]] && verb="is"
+
+        error_message="$failed_services $verb unreachable. Please contact your admin."
         # Example error message: Redshift Clusters, Athena, STS, Glue are unreachable. Please contact your admin.
         write_status_to_file "error" "$error_message"
         echo "$error_message"

--- a/template/v3/dirs/etc/sagemaker-ui/network_validation.sh
+++ b/template/v3/dirs/etc/sagemaker-ui/network_validation.sh
@@ -126,14 +126,18 @@ temp_dir=$(mktemp -d)
 # Launch all service API checks in parallel background jobs
 for service in "${!SERVICE_COMMANDS[@]}"; do
   {
-    # Run command with timeout, discard stdout/stderr
-    if timeout "${api_time_out_limit}s" bash -c "${SERVICE_COMMANDS[$service]}" > /dev/null 2>&1; then
+    output_file="$temp_dir/${service}_output"
+
+    # Run command with timeout
+    if timeout "${api_time_out_limit}s" bash -c "${SERVICE_COMMANDS[$service]}" > "$output_file" 2>&1; then
       # Success: write OK to temp file
       echo "OK" > "$temp_dir/$service"
     else
       # Get exit code to differentiate timeout or other errors
       exit_code=$?
-      if [ "$exit_code" -eq 124 ]; then
+      if grep -q "Could not connect to the endpoint URL" "$output_file"; then
+        echo "UNREACHABLE" > "$temp_dir/$service"
+      elif [ "$exit_code" -eq 124 ]; then
         # Timeout exit code
         echo "TIMEOUT" > "$temp_dir/$service"
       else
@@ -155,10 +159,13 @@ for service in "${!SERVICE_COMMANDS[@]}"; do
     if [[ "$result" == "TIMEOUT" ]]; then
       echo "$service API did NOT resolve within ${api_time_out_limit}s. Marking as unreachable."
       unreachable_services+=("$service")
+    elif [[ "$result" == "UNREACHABLE" ]]; then
+      echo "$service API failed to connect to the endpoint. Marking as unreachable."
+      unreachable_services+=("$service")
     elif [[ "$result" == "OK" ]]; then
       echo "$service API is reachable."
     else
-      echo "$service API returned an error (but not a timeout). Ignored for network check."
+      echo "$service API returned an error (but not a timeout or endpoint reachability failure). Ignored for network check."
     fi
   else
     echo "$service check did not produce a result file. Skipping."

--- a/template/v3/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/template/v3/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -241,7 +241,13 @@ if bash /etc/sagemaker-ui/network_validation.sh "$is_s3_storage_flag" "$network_
     # Read unreachable services from JSON file
     failed_services=$(jq -r '.UnreachableServices // empty' "$network_validation_file" || echo "")
     if [[ -n "$failed_services" ]]; then
-        error_message="$failed_services are unreachable. Please contact your admin."
+        # Count number of services by splitting on comma
+        IFS=',' read -ra failed_array <<< "$failed_services"
+        count=${#failed_array[@]}
+        verb="are"
+        [[ "$count" -eq 1 ]] && verb="is"
+
+        error_message="$failed_services $verb unreachable. Please contact your admin."
         # Example error message: Redshift Clusters, Athena, STS, Glue are unreachable. Please contact your admin.
         write_status_to_file "error" "$error_message"
         echo "$error_message"


### PR DESCRIPTION
## Description
    If a user has access to the internet, but does not have a VPC Endpoint attached to their network, API calls made within the network_validation script may fail due to "Could not connect to the endpoint URL". This change ensures these errors are caught and surfaced to the user.


## Type of Change
- [X] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [] Yes (Critical bug fix or security update)
- [X] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]

## How Has This Been Tested?
    Tested in a SMUS portal containing internet, no internet, no internet with VPC Endpoints to Datazone and s3 AND internet with only certain VPC endpoints.

## Checklist:
- [X] My code follows the style guidelines of this project
- [ X I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
[Link any related issues here]

## Additional Notes
[Any additional information that might be helpful for reviewers]
