### PR TITLE
fix(workflows-unified-storage): export MOUNT_DIR for stop workflows container script to use it

### DIFF
--- a/template/v2/dirs/etc/sagemaker-ui/workflows/start-workflows-container.sh
+++ b/template/v2/dirs/etc/sagemaker-ui/workflows/start-workflows-container.sh
@@ -3,11 +3,7 @@ set -eu
 
 # Get project directory based on storage type
 PROJECT_DIR=${SMUS_PROJECT_DIR:-"$HOME/src"}
-if [ -z "$SMUS_PROJECT_DIR" ]; then
-    export MOUNT_DIR=$PROJECT_DIR
-else
-    export MOUNT_DIR=$(readlink -f "$PROJECT_DIR")  # get the symlink source
-fi
+MOUNT_DIR=$(readlink -f "$PROJECT_DIR")  # get the symlink source if it's symlink
 
 # Datazone project metadata
 RESOURCE_METADATA_FILE=/opt/ml/metadata/resource-metadata.json

--- a/template/v2/dirs/etc/sagemaker-ui/workflows/stop-workflows-container.sh
+++ b/template/v2/dirs/etc/sagemaker-ui/workflows/stop-workflows-container.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 
+PROJECT_DIR=${SMUS_PROJECT_DIR:-"$HOME/src"}
+MOUNT_DIR=$(readlink -f "$PROJECT_DIR")  # get the symlink source if it's symlink
+
 DOCKER_EXECUTABLE=$(which docker)
 
 # Stop healthchecker
 supervisorctl -s unix:///var/run/supervisord/supervisor.sock stop workflows_healthcheck
 
 # Stop the containers
+export MOUNT_DIR=$MOUNT_DIR
 $DOCKER_EXECUTABLE compose -f /etc/sagemaker-ui/workflows/docker-compose.yaml down
 
 # Update status to stopped

--- a/template/v3/dirs/etc/sagemaker-ui/workflows/start-workflows-container.sh
+++ b/template/v3/dirs/etc/sagemaker-ui/workflows/start-workflows-container.sh
@@ -3,11 +3,7 @@ set -eu
 
 # Get project directory based on storage type
 PROJECT_DIR=${SMUS_PROJECT_DIR:-"$HOME/src"}
-if [ -z "$SMUS_PROJECT_DIR" ]; then
-    export MOUNT_DIR=$PROJECT_DIR
-else
-    export MOUNT_DIR=$(readlink -f "$PROJECT_DIR")  # get the symlink source
-fi
+MOUNT_DIR=$(readlink -f "$PROJECT_DIR")  # get the symlink source if it's symlink
 
 # Datazone project metadata
 RESOURCE_METADATA_FILE=/opt/ml/metadata/resource-metadata.json

--- a/template/v3/dirs/etc/sagemaker-ui/workflows/stop-workflows-container.sh
+++ b/template/v3/dirs/etc/sagemaker-ui/workflows/stop-workflows-container.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 
+PROJECT_DIR=${SMUS_PROJECT_DIR:-"$HOME/src"}
+MOUNT_DIR=$(readlink -f "$PROJECT_DIR")  # get the symlink source if it's symlink
+
 DOCKER_EXECUTABLE=$(which docker)
 
 # Stop healthchecker
 supervisorctl -s unix:///var/run/supervisord/supervisor.sock stop workflows_healthcheck
 
 # Stop the containers
+export MOUNT_DIR=$MOUNT_DIR
 $DOCKER_EXECUTABLE compose -f /etc/sagemaker-ui/workflows/docker-compose.yaml down
 
 # Update status to stopped


### PR DESCRIPTION
## Description
the `MOUNT_DIR` is set in the `etc/sagemaker-ui/workflows/start-workflows-container.sh` and then passed to docker compose:
```
PROJECT_DIR=$(basename $PROJECT_DIR)  \
MOUNT_DIR=$MOUNT_DIR \
ECR_ACCOUNT_ID=$ECR_ACCOUNT_ID \
ACCOUNT_ID=$AWS_ACCOUNT_ID \
DZ_DOMAIN_ID=$DZ_DOMAIN_ID \
DZ_PROJECT_ID=$DZ_PROJECT_ID \
DZ_ENV_ID=$DZ_ENV_ID \
DZ_DOMAIN_REGION=$DZ_DOMAIN_REGION \
DZ_PROJECT_S3PATH=$DZ_PROJECT_S3PATH \
  docker compose -f /etc/sagemaker-ui/workflows/docker-compose.yaml up -d --quiet-pull
) || handle_workflows_startup_error 5
```
as the same docker compose file is also used in the stop workflows container script, it requires the `MOUNT_DIR` to be set 
when run `$DOCKER_EXECUTABLE compose -f /etc/sagemaker-ui/workflows/docker-compose.yaml down`, currently seeing this error when running the script `bash /etc/sagemaker-ui/workflows/stop-workflows-container.sh` indicating it's missing MOUNT_DIR: `invalid spec: :/home/sagemaker-user/src:rw: empty section between colons`


## Type of Change
- [x] Image update - Bug fix
- [x] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [x] Yes (Critical bug fix or security update): needs to be included for 2.8/2.9/3.3/3.4 for unified storage launch
- [ ] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]

## How Has This Been Tested?
tested by export the MOUNT_DIR and re-run the stop container script, verified the containers were successfully stopped:
```
sagemaker-user@default:~$ bash /etc/sagemaker-ui/workflows/stop-workflows-container.sh
/opt/conda/lib/python3.11/site-packages/supervisor/options.py:13: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
workflows_healthcheck: ERROR (not running)
WARN[0000] The "ACCOUNT_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DZ_DOMAIN_REGION" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DZ_PROJECT_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DZ_ENV_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "ACCOUNT_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DZ_DOMAIN_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "ACCOUNT_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "ACCOUNT_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "ACCOUNT_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "ACCOUNT_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DZ_PROJECT_S3PATH" variable is not set. Defaulting to a blank string. 
WARN[0000] The "PROJECT_DIR" variable is not set. Defaulting to a blank string. 
WARN[0000] The "ACCOUNT_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DZ_PROJECT_S3PATH" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DZ_PROJECT_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "ACCOUNT_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "ACCOUNT_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DZ_DOMAIN_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "ACCOUNT_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DZ_DOMAIN_REGION" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DZ_ENV_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "ACCOUNT_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "ACCOUNT_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "PROJECT_DIR" variable is not set. Defaulting to a blank string. 
WARN[0000] The "ACCOUNT_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DZ_PROJECT_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DZ_DOMAIN_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "ACCOUNT_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "ACCOUNT_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "ACCOUNT_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DZ_DOMAIN_REGION" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DZ_PROJECT_S3PATH" variable is not set. Defaulting to a blank string. 
WARN[0000] The "ACCOUNT_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "DZ_ENV_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "ACCOUNT_ID" variable is not set. Defaulting to a blank string. 
WARN[0000] The "PROJECT_DIR" variable is not set. Defaulting to a blank string. 
[+] Running 3/3
 ✔ Container mwaa-292-scheduler  Removed                                                      4.5s 
 ✔ Container mwaa-292-webserver  Removed                                                      4.2s 
 ✔ Container mwaa-292-db         Removed                                                             0.1s
```

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
[Link any related issues here]

## Additional Notes
[Any additional information that might be helpful for reviewers]
