### PR TITLE
Feat: add custom inference port control to enable accept-bind-to-port for MCE + Inference Pipelines

### DIFF
--- a/template/v3/Dockerfile
+++ b/template/v3/Dockerfile
@@ -7,6 +7,7 @@ ARG PINNED_ENV_IN_FILENAME
 ARG ARG_BASED_ENV_IN_FILENAME
 ARG IMAGE_VERSION
 LABEL "org.amazon.sagemaker-distribution.image.version"=$IMAGE_VERSION
+LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
 ARG AMZN_BASE="/opt/amazon/sagemaker"
 ARG DB_ROOT_DIR="/opt/db"

--- a/template/v3/dirs/etc/sagemaker-inference-server/utils/environment.py
+++ b/template/v3/dirs/etc/sagemaker-inference-server/utils/environment.py
@@ -5,8 +5,14 @@ import os
 from enum import Enum
 
 
+class SageMakerPlatform(str, Enum):
+    """Simple enum to define environment variables injected by the SageMaker platform."""
+
+    PLATFORM_PORT = "SAGEMAKER_BIND_TO_PORT"
+
+
 class SageMakerInference(str, Enum):
-    """Simple enum to define the mapping between dictionary key and environement variable."""
+    """Simple enum to define the mapping between dictionary key and environment variable."""
 
     BASE_DIRECTORY = "SAGEMAKER_INFERENCE_BASE_DIRECTORY"
     REQUIREMENTS = "SAGEMAKER_INFERENCE_REQUIREMENTS"
@@ -28,7 +34,7 @@ class Environment:
             SageMakerInference.CODE_DIRECTORY: os.getenv(SageMakerInference.CODE_DIRECTORY, None),
             SageMakerInference.CODE: os.getenv(SageMakerInference.CODE, "inference.handler"),
             SageMakerInference.LOG_LEVEL: os.getenv(SageMakerInference.LOG_LEVEL, 10),
-            SageMakerInference.PORT: 8080,
+            SageMakerInference.PORT: self._resolve_port(),
         }
 
     def __str__(self):
@@ -57,3 +63,10 @@ class Environment:
     @property
     def port(self):
         return self._environment_variables.get(SageMakerInference.PORT)
+
+    def _resolve_port(self) -> int:
+        if os.getenv(SageMakerPlatform.PLATFORM_PORT, None):
+            return int(os.getenv(SageMakerPlatform.PLATFORM_PORT))
+        if os.getenv(SageMakerInference.PORT, None):
+            return int(os.getenv(SageMakerInference.PORT))
+        return 8080


### PR DESCRIPTION
## Description
To enable multi container endpoint (MCE) + Inference Pipeline capabilities on SMD container, the following have been added:
1. The inference server now accepts `SAGEMAKER_BIND_TO_PORT` as a way to configure the listening port
2. Additionally label the container to accept bind to port

Ref: https://docs.aws.amazon.com/sagemaker/latest/dg/multi-container-troubleshooting.html#multi-container-missing-accept

## Type of Change
- [ ] Image update - Bug fix
- [x] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ ] Yes (Critical bug fix or security update)
- [x] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]

## How Has This Been Tested?
[Describe the tests you ran]

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
https://github.com/aws/sagemaker-distribution/issues/645
https://github.com/aws/sagemaker-distribution/issues/644

## Additional Notes
[Any additional information that might be helpful for reviewers]
