### PR TITLE
feat: add Amazon Q agent configuration and MCP migration

### DIFF
--- a/template/v2/dirs/etc/sagemaker-ui/sagemaker-mcp/default.json
+++ b/template/v2/dirs/etc/sagemaker-ui/sagemaker-mcp/default.json
@@ -3,18 +3,22 @@
     "version": "1.0.0",
     "description": "Default agent configuration",
     "mcpServers": {
-        "smus-local-mcp": {
-          "command": "python",  
-          "args": ["/etc/sagemaker-ui/sagemaker-mcp/smus-mcp.py"]
-        }
-      },
+      "smus-local-mcp": {
+        "command": "python",
+        "args": [
+          "/etc/sagemaker-ui/sagemaker-mcp/smus-mcp.py"
+        ],
+        "env": {}
+      }
+    },
     "tools": [
       "fsRead",
       "fsWrite",
       "fsReplace",
       "listDirectory",
       "fileSearch",
-      "executeBash"
+      "executeBash",
+      "@smus-local-mcp"
     ],
     "allowedTools": [
       "fsRead",
@@ -39,10 +43,6 @@
         ]
       }
     },
-    "includedFiles": [
-      "AmazonQ.md",
-      "README.md",
-      ".amazonq/rules/**/*.md"
-    ],
+    "includedFiles": [],
     "resources": []
   }

--- a/template/v2/dirs/etc/sagemaker-ui/sagemaker-mcp/default.json
+++ b/template/v2/dirs/etc/sagemaker-ui/sagemaker-mcp/default.json
@@ -1,0 +1,48 @@
+{
+    "name": "default-agent",
+    "version": "1.0.0",
+    "description": "Default agent configuration",
+    "mcpServers": {
+        "smus-local-mcp": {
+          "command": "python",  
+          "args": ["/etc/sagemaker-ui/sagemaker-mcp/smus-mcp.py"]
+        }
+      },
+    "tools": [
+      "fsRead",
+      "fsWrite",
+      "fsReplace",
+      "listDirectory",
+      "fileSearch",
+      "executeBash"
+    ],
+    "allowedTools": [
+      "fsRead",
+      "fsWrite",
+      "fsReplace",
+      "listDirectory",
+      "fileSearch"
+    ],
+    "toolsSettings": {
+      "execute_bash": {
+        "alwaysAllow": [
+          {
+            "preset": "readOnly"
+          }
+        ]
+      },
+      "use_aws": {
+        "alwaysAllow": [
+          {
+            "preset": "readOnly"
+          }
+        ]
+      }
+    },
+    "includedFiles": [
+      "AmazonQ.md",
+      "README.md",
+      ".amazonq/rules/**/*.md"
+    ],
+    "resources": []
+  }

--- a/template/v2/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/template/v2/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -303,6 +303,61 @@ else
     echo "Warning: MCP configuration file not found at $source_file"
 fi
 
+# Migrating MCP configuration to new config file
+echo "Migrating MCP configuration to Amazon Q agents..."
+agents_target_file="$HOME/.aws/amazonq/agents/default.json"
+agents_source_file="/etc/sagemaker-ui/sagemaker-mcp/default.json"
+
+if [ -f "$agents_source_file" ]; then
+    mkdir -p "$HOME/.aws/amazonq/agents/"
+    
+    if [ -f "$agents_target_file" ]; then
+        echo "Existing Amazon Q agents configuration found, merging mcpServers..."
+        
+        # Check if target file is valid JSON
+        if jq empty "$agents_target_file" 2>/dev/null; then
+            # Initialize mcpServers object if it doesn't exist in target
+            if ! jq -e '.mcpServers' "$agents_target_file" >/dev/null 2>&1; then
+                echo "Creating mcpServers object in existing agents configuration"
+                jq '. + {"mcpServers":{}}' "$agents_target_file" > "$agents_target_file.tmp"
+                mv "$agents_target_file.tmp" "$agents_target_file"
+            fi
+            
+            # Add servers from source that don't exist in target
+            if jq -e '.mcpServers' "$agents_source_file" >/dev/null 2>&1; then
+                source_server_names=$(jq -r '.mcpServers | keys[]' "$agents_source_file")
+                
+                for server_name in $source_server_names; do
+                    if ! jq -e ".mcpServers.\"$server_name\"" "$agents_target_file" >/dev/null 2>&1; then
+                        # Server doesn't exist in target - add it
+                        server_config=$(jq ".mcpServers.\"$server_name\"" "$agents_source_file")
+                        jq --arg name "$server_name" --argjson config "$server_config" \
+                            '.mcpServers[$name] = $config' "$agents_target_file" > "$agents_target_file.tmp"
+                        mv "$agents_target_file.tmp" "$agents_target_file"
+                        echo "Added server '$server_name' to agents configuration"
+                    else
+                        echo "Server '$server_name' already exists in configuration, skipping"
+                    fi
+                done
+                
+                echo "Successfully added missing mcpServers from default.json to agents configuration"
+            else
+                echo "No mcpServers found in source configuration"
+            fi
+        else
+            echo "Warning: Existing agents configuration is not valid JSON, replacing with default configuration"
+            cp "$agents_source_file" "$agents_target_file"
+        fi
+    else
+        cp "$agents_source_file" "$agents_target_file"
+        echo "Created new Amazon Q agents configuration file"
+    fi
+    
+    echo "Successfully migrated MCP configuration to Amazon Q agents"
+else
+    echo "Warning: Source configuration file not found at $agents_source_file"
+fi
+
 # Generate sagemaker pysdk intelligent default config
 nohup python /etc/sagemaker/sm_pysdk_default_config.py &
 # Only run the following commands if SAGEMAKER_APP_TYPE_LOWERCASE is jupyterlab and domain is not in express mode

--- a/template/v2/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/template/v2/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -323,7 +323,7 @@ if [ -f "$agents_source_file" ]; then
                 mv "$agents_target_file.tmp" "$agents_target_file"
             fi
             
-            # Add servers from source that don't exist in target
+            # Add servers from source that don't exist in target and update tools
             if jq -e '.mcpServers' "$agents_source_file" >/dev/null 2>&1; then
                 source_server_names=$(jq -r '.mcpServers | keys[]' "$agents_source_file")
                 
@@ -335,12 +335,29 @@ if [ -f "$agents_source_file" ]; then
                             '.mcpServers[$name] = $config' "$agents_target_file" > "$agents_target_file.tmp"
                         mv "$agents_target_file.tmp" "$agents_target_file"
                         echo "Added server '$server_name' to agents configuration"
+                        
+                        # Check if source has tools that reference this server and add them
+                        server_tool_ref="@$server_name"
+                        if jq -e --arg tool "$server_tool_ref" '.tools | index($tool)' "$agents_source_file" >/dev/null 2>&1; then
+                            # Initialize tools array if it doesn't exist
+                            if ! jq -e '.tools' "$agents_target_file" >/dev/null 2>&1; then
+                                jq '. + {"tools":[]}' "$agents_target_file" > "$agents_target_file.tmp"
+                                mv "$agents_target_file.tmp" "$agents_target_file"
+                            fi
+                            
+                            # Add tool reference if it doesn't exist
+                            if ! jq -e --arg tool "$server_tool_ref" '.tools | index($tool)' "$agents_target_file" >/dev/null 2>&1; then
+                                jq --arg tool "$server_tool_ref" '.tools += [$tool]' "$agents_target_file" > "$agents_target_file.tmp"
+                                mv "$agents_target_file.tmp" "$agents_target_file"
+                                echo "Added tool reference '$server_tool_ref' to agents configuration"
+                            fi
+                        fi
                     else
                         echo "Server '$server_name' already exists in configuration, skipping"
                     fi
                 done
                 
-                echo "Successfully added missing mcpServers from default.json to agents configuration"
+                echo "Successfully added missing mcpServers and tools from default.json to agents configuration"
             else
                 echo "No mcpServers found in source configuration"
             fi

--- a/template/v3/dirs/etc/sagemaker-ui/sagemaker-mcp/default.json
+++ b/template/v3/dirs/etc/sagemaker-ui/sagemaker-mcp/default.json
@@ -1,0 +1,48 @@
+{
+    "name": "default-agent",
+    "version": "1.0.0",
+    "description": "Default agent configuration",
+    "mcpServers": {
+        "smus-local-mcp": {
+          "command": "python",  
+          "args": ["/etc/sagemaker-ui/sagemaker-mcp/smus-mcp.py"]
+        }
+      },
+    "tools": [
+      "fsRead",
+      "fsWrite",
+      "fsReplace",
+      "listDirectory",
+      "fileSearch",
+      "executeBash"
+    ],
+    "allowedTools": [
+      "fsRead",
+      "fsWrite",
+      "fsReplace",
+      "listDirectory",
+      "fileSearch"
+    ],
+    "toolsSettings": {
+      "execute_bash": {
+        "alwaysAllow": [
+          {
+            "preset": "readOnly"
+          }
+        ]
+      },
+      "use_aws": {
+        "alwaysAllow": [
+          {
+            "preset": "readOnly"
+          }
+        ]
+      }
+    },
+    "includedFiles": [
+      "AmazonQ.md",
+      "README.md",
+      ".amazonq/rules/**/*.md"
+    ],
+    "resources": []
+  }

--- a/template/v3/dirs/etc/sagemaker-ui/sagemaker-mcp/default.json
+++ b/template/v3/dirs/etc/sagemaker-ui/sagemaker-mcp/default.json
@@ -1,48 +1,48 @@
 {
-    "name": "default-agent",
-    "version": "1.0.0",
-    "description": "Default agent configuration",
-    "mcpServers": {
-        "smus-local-mcp": {
-          "command": "python",  
-          "args": ["/etc/sagemaker-ui/sagemaker-mcp/smus-mcp.py"]
+  "name": "default-agent",
+  "version": "1.0.0",
+  "description": "Default agent configuration",
+  "mcpServers": {
+    "smus-local-mcp": {
+      "command": "python",
+      "args": [
+        "/etc/sagemaker-ui/sagemaker-mcp/smus-mcp.py"
+      ],
+      "env": {}
+    }
+  },
+  "tools": [
+    "fsRead",
+    "fsWrite",
+    "fsReplace",
+    "listDirectory",
+    "fileSearch",
+    "executeBash",
+    "@smus-local-mcp"
+  ],
+  "allowedTools": [
+    "fsRead",
+    "fsWrite",
+    "fsReplace",
+    "listDirectory",
+    "fileSearch"
+  ],
+  "toolsSettings": {
+    "execute_bash": {
+      "alwaysAllow": [
+        {
+          "preset": "readOnly"
         }
-      },
-    "tools": [
-      "fsRead",
-      "fsWrite",
-      "fsReplace",
-      "listDirectory",
-      "fileSearch",
-      "executeBash"
-    ],
-    "allowedTools": [
-      "fsRead",
-      "fsWrite",
-      "fsReplace",
-      "listDirectory",
-      "fileSearch"
-    ],
-    "toolsSettings": {
-      "execute_bash": {
-        "alwaysAllow": [
-          {
-            "preset": "readOnly"
-          }
-        ]
-      },
-      "use_aws": {
-        "alwaysAllow": [
-          {
-            "preset": "readOnly"
-          }
-        ]
-      }
+      ]
     },
-    "includedFiles": [
-      "AmazonQ.md",
-      "README.md",
-      ".amazonq/rules/**/*.md"
-    ],
-    "resources": []
-  }
+    "use_aws": {
+      "alwaysAllow": [
+        {
+          "preset": "readOnly"
+        }
+      ]
+    }
+  },
+  "includedFiles": [],
+  "resources": []
+}

--- a/template/v3/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/template/v3/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -304,6 +304,61 @@ else
     echo "Warning: MCP configuration file not found at $source_file"
 fi
 
+# Migrating MCP configuration to new config file
+echo "Migrating MCP configuration to Amazon Q agents..."
+agents_target_file="$HOME/.aws/amazonq/agents/default.json"
+agents_source_file="/etc/sagemaker-ui/sagemaker-mcp/default.json"
+
+if [ -f "$agents_source_file" ]; then
+    mkdir -p "$HOME/.aws/amazonq/agents/"
+    
+    if [ -f "$agents_target_file" ]; then
+        echo "Existing Amazon Q agents configuration found, merging mcpServers..."
+        
+        # Check if target file is valid JSON
+        if jq empty "$agents_target_file" 2>/dev/null; then
+            # Initialize mcpServers object if it doesn't exist in target
+            if ! jq -e '.mcpServers' "$agents_target_file" >/dev/null 2>&1; then
+                echo "Creating mcpServers object in existing agents configuration"
+                jq '. + {"mcpServers":{}}' "$agents_target_file" > "$agents_target_file.tmp"
+                mv "$agents_target_file.tmp" "$agents_target_file"
+            fi
+            
+            # Add servers from source that don't exist in target
+            if jq -e '.mcpServers' "$agents_source_file" >/dev/null 2>&1; then
+                source_server_names=$(jq -r '.mcpServers | keys[]' "$agents_source_file")
+                
+                for server_name in $source_server_names; do
+                    if ! jq -e ".mcpServers.\"$server_name\"" "$agents_target_file" >/dev/null 2>&1; then
+                        # Server doesn't exist in target - add it
+                        server_config=$(jq ".mcpServers.\"$server_name\"" "$agents_source_file")
+                        jq --arg name "$server_name" --argjson config "$server_config" \
+                            '.mcpServers[$name] = $config' "$agents_target_file" > "$agents_target_file.tmp"
+                        mv "$agents_target_file.tmp" "$agents_target_file"
+                        echo "Added server '$server_name' to agents configuration"
+                    else
+                        echo "Server '$server_name' already exists in configuration, skipping"
+                    fi
+                done
+                
+                echo "Successfully added missing mcpServers from default.json to agents configuration"
+            else
+                echo "No mcpServers found in source configuration"
+            fi
+        else
+            echo "Warning: Existing agents configuration is not valid JSON, replacing with default configuration"
+            cp "$agents_source_file" "$agents_target_file"
+        fi
+    else
+        cp "$agents_source_file" "$agents_target_file"
+        echo "Created new Amazon Q agents configuration file"
+    fi
+    
+    echo "Successfully migrated MCP configuration to Amazon Q agents"
+else
+    echo "Warning: Source configuration file not found at $agents_source_file"
+fi
+
 # Generate sagemaker pysdk intelligent default config
 nohup python /etc/sagemaker/sm_pysdk_default_config.py &
 # Only run the following commands if SAGEMAKER_APP_TYPE_LOWERCASE is jupyterlab and domain is not in express mode


### PR DESCRIPTION
- Add default.json configuration files for Amazon Q agents in v2 and v3 templates
- Add migration logic in post-startup scripts to merge MCP configurations
- Support intelligent merging of existing agent configurations

## Description
[Provide a brief description of the changes]

## Type of Change
- [x] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [x] Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
Due to some dependencies logic changes the agentic chat mcp configuration file location changed. This PR is adding a migration logic when space run the post startup script.

## How Has This Been Tested?
Yes, tested the migration logic in a SMUS space to run the bash file separately. 

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
[Link any related issues here]

## Additional Notes
[Any additional information that might be helpful for reviewers]
