### PR TITLE
Pin Q CLI to v1.12.7

### DIFF
--- a/template/v2/Dockerfile
+++ b/template/v2/Dockerfile
@@ -63,7 +63,7 @@ RUN apt-get update && apt-get upgrade -y && \
     rm -rf aws awscliv2.zip && \
     : && \
     # Install Q CLI
-    curl --proto '=https' --tlsv1.2 -sSf "https://desktop-release.q.us-east-1.amazonaws.com/latest/q-x86_64-linux.zip" -o "q.zip" && \
+    curl --proto '=https' --tlsv1.2 -sSf "https://desktop-release.q.us-east-1.amazonaws.com/1.12.7/q-x86_64-linux.zip" -o "q.zip" && \
     unzip q.zip && \
     Q_INSTALL_GLOBAL=true ./q/install.sh --no-confirm && \
     rm -rf q q.zip && \

--- a/template/v3/Dockerfile
+++ b/template/v3/Dockerfile
@@ -63,7 +63,7 @@ RUN apt-get update && apt-get upgrade -y && \
     rm -rf aws awscliv2.zip && \
     : && \
     # Install Q CLI
-    curl --proto '=https' --tlsv1.2 -sSf "https://desktop-release.q.us-east-1.amazonaws.com/latest/q-x86_64-linux.zip" -o "q.zip" && \
+    curl --proto '=https' --tlsv1.2 -sSf "https://desktop-release.q.us-east-1.amazonaws.com/1.12.7/q-x86_64-linux.zip" -o "q.zip" && \
     unzip q.zip && \
     Q_INSTALL_GLOBAL=true ./q/install.sh --no-confirm && \
     rm -rf q q.zip && \


### PR DESCRIPTION
## Description
This change pins Q CLI to version 1.12.7

## Type of Change
- [x] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [x] Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
To avoid a potentially breaking Q CLI change, we are pinning the version for now.

## How Has This Been Tested?
Verified Q CLI v1.12.7 in a SageMaker Unified Studio project.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
N/A

## Additional Notes
Related PR: https://github.com/aws/sagemaker-distribution/pull/799
