### PR TITLE
Move Q CLI telemetry and add domain mode to post-startup script

### DIFF
--- a/template/v2/dirs/usr/local/bin/entrypoint-sagemaker-ui-code-editor
+++ b/template/v2/dirs/usr/local/bin/entrypoint-sagemaker-ui-code-editor
@@ -11,7 +11,6 @@ micromamba activate base
 
 export SAGEMAKER_APP_TYPE_LOWERCASE=$(echo $SAGEMAKER_APP_TYPE | tr '[:upper:]' '[:lower:]')
 export SERVICE_NAME='SageMakerUnifiedStudio'
-export Q_CLI_CLIENT_APPLICATION='SMUS_CODE_EDITOR'
 
 mkdir -p $STUDIO_LOGGING_DIR/$SAGEMAKER_APP_TYPE_LOWERCASE/supervisord
 exec supervisord -c /etc/supervisor/conf.d/supervisord-sagemaker-ui-code-editor.conf -n

--- a/template/v2/dirs/usr/local/bin/entrypoint-sagemaker-ui-jupyter-server
+++ b/template/v2/dirs/usr/local/bin/entrypoint-sagemaker-ui-jupyter-server
@@ -21,7 +21,6 @@ fi
 
 export SAGEMAKER_APP_TYPE_LOWERCASE=$(echo $SAGEMAKER_APP_TYPE | tr '[:upper:]' '[:lower:]')
 export SERVICE_NAME='SageMakerUnifiedStudio'
-export Q_CLI_CLIENT_APPLICATION='SMUS_JUPYTER_LAB'
 
 mkdir -p $STUDIO_LOGGING_DIR/$SAGEMAKER_APP_TYPE_LOWERCASE/supervisord
 exec supervisord -c /etc/supervisor/conf.d/supervisord-sagemaker-ui.conf -n

--- a/template/v3/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/template/v3/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -103,11 +103,23 @@ is_express_mode=$(echo "$cleaned_response" | jq -r '.preferences.DOMAIN_MODE == 
 
 if [ "$is_express_mode" = "true" ]; then
     echo "Domain is in express mode. Using default credentials"
+    if grep -q "^DOMAIN_MODE=" ~/.bashrc; then
+        echo "DOMAIN_MODE is defined in the env"
+    else
+        echo DOMAIN_MODE="EXPRESS" >> ~/.bashrc
+        echo readonly DOMAIN_MODE >> ~/.bashrc
+    fi
     # Use default credentials - no additional configuration needed
     aws configure set credential_source EcsContainer --profile DomainExecutionRoleCreds
     echo "Successfully configured DomainExecutionRoleCreds profile with default credentials"
 else
     echo "Domain is not in express mode"
+    if grep -q "^DOMAIN_MODE=" ~/.bashrc; then
+        echo "DOMAIN_MODE is defined in the env"
+    else
+        echo DOMAIN_MODE="NON_EXPRESS" >> ~/.bashrc
+        echo readonly DOMAIN_MODE >> ~/.bashrc
+    fi
     # Setting this to +x to not log credentials from the response of fetching credentials.
     set +x
     # Note: The $? check immediately follows the sagemaker-studio command to ensure we're checking its exit status.
@@ -252,6 +264,23 @@ if $AMAZON_Q_SIGV4; then
 else 
     # Remove from .bashrc if it exists
     sed -i '/^export AMAZON_Q_SIGV4=/d' ~/.bashrc
+fi
+
+# Setup Q CLI telemetry
+if [ "${SAGEMAKER_APP_TYPE_LOWERCASE}" = "jupyterlab" ]; then
+    q_cli_client_application="SMUS_JUPYTER_LAB"
+else
+    q_cli_client_application="SMUS_CODE_EDITOR"
+fi
+if [ "$is_express_mode" = "true" ]; then
+    q_cli_client_application="${q_cli_client_application}_EXPRESS"
+fi
+
+if grep -q "^export Q_CLI_CLIENT_APPLICATION=" ~/.bashrc; then
+    echo Q_CLI_CLIENT_APPLICATION is defined in the env
+else
+    echo export Q_CLI_CLIENT_APPLICATION=$q_cli_client_application >> ~/.bashrc
+    echo readonly Q_CLI_CLIENT_APPLICATION >> ~/.bashrc
 fi
 
 # Setup SageMaker MCP configuration

--- a/template/v3/dirs/usr/local/bin/entrypoint-sagemaker-ui-code-editor
+++ b/template/v3/dirs/usr/local/bin/entrypoint-sagemaker-ui-code-editor
@@ -11,7 +11,6 @@ micromamba activate base
 
 export SAGEMAKER_APP_TYPE_LOWERCASE=$(echo $SAGEMAKER_APP_TYPE | tr '[:upper:]' '[:lower:]')
 export SERVICE_NAME='SageMakerUnifiedStudio'
-export Q_CLI_CLIENT_APPLICATION='SMUS_CODE_EDITOR'
 
 mkdir -p $STUDIO_LOGGING_DIR/$SAGEMAKER_APP_TYPE_LOWERCASE/supervisord
 exec supervisord -c /etc/supervisor/conf.d/supervisord-sagemaker-ui-code-editor.conf -n

--- a/template/v3/dirs/usr/local/bin/entrypoint-sagemaker-ui-jupyter-server
+++ b/template/v3/dirs/usr/local/bin/entrypoint-sagemaker-ui-jupyter-server
@@ -21,7 +21,6 @@ fi
 
 export SAGEMAKER_APP_TYPE_LOWERCASE=$(echo $SAGEMAKER_APP_TYPE | tr '[:upper:]' '[:lower:]')
 export SERVICE_NAME='SageMakerUnifiedStudio'
-export Q_CLI_CLIENT_APPLICATION='SMUS_JUPYTER_LAB'
 
 mkdir -p $STUDIO_LOGGING_DIR/$SAGEMAKER_APP_TYPE_LOWERCASE/supervisord
 exec supervisord -c /etc/supervisor/conf.d/supervisord-sagemaker-ui.conf -n


### PR DESCRIPTION
## Description
This change moves the Q CLI telemetry setup to the post-startup script, adds domain mode handling for the Q CLI telemetry, and tracks the domain mode in an environment variable using the `.bashrc` file.

## Type of Change
- [x] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [x] Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
To make sure we capture accurate environment telemetry, we need this change in SMD v2.9 and v3.4 patch versions.

## How Has This Been Tested?
I built the image locally following the contribution guide and used BYOI to test the script changes in SageMaker Unified Studio. I made sure the variables were being set accurately and the Q CLI logs included the corresponding info.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
N/A

## Additional Notes
