### PR TITLE
Add SQLiteYStore and ArbitraryFileIdManager database paths to start-sagemaker-ui-jupyter-server script to v2 template

### DIFF
--- a/template/v2/dirs/usr/local/bin/start-sagemaker-ui-jupyter-server
+++ b/template/v2/dirs/usr/local/bin/start-sagemaker-ui-jupyter-server
@@ -43,7 +43,9 @@ if [ -n "$SAGEMAKER_RECOVERY_MODE" ]; then
     --ServerApp.base_url="/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
     --ServerApp.token='' \
     --ServerApp.allow_origin='*' \
-    --SchedulerApp.db_url='sqlite:////tmp/.jupyter_scheduler_do_not_delete.sqlite'
+    --SchedulerApp.db_url='sqlite:////tmp/.jupyter_scheduler_do_not_delete.sqlite' \
+    --SQLiteYStore.db_path='/tmp/.ydoc_db_do_not_delete.sqlite' \
+    --ArbitraryFileIdManager.db_path='/tmp/.fileid_do_not_delete.sqlite'
 else 
   jupyter lab --ip 0.0.0.0 --port 8888 \
     --ServerApp.base_url="/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
@@ -51,5 +53,7 @@ else
     --ServerApp.allow_origin='*' \
     --SchedulerApp.db_url='sqlite:////tmp/.jupyter_scheduler_do_not_delete.sqlite' \
     --collaborative \
-    --ServerApp.identity_provider_class='sagemaker_jupyter_server_extension.identity.SageMakerIdentityProvider' 
-fi 
+    --ServerApp.identity_provider_class='sagemaker_jupyter_server_extension.identity.SageMakerIdentityProvider' \
+    --SQLiteYStore.db_path='/tmp/.ydoc_db_do_not_delete.sqlite'  \
+    --ArbitraryFileIdManager.db_path='/tmp/.fileid_do_not_delete.sqlite'
+fi


### PR DESCRIPTION
Add SQLiteYStore and ArbitraryFileIdManager database paths to start-sagemaker-ui-jupyter-server script to v2 template
**Description**

This changes adds SQLiteYStore and ArbitraryFileIdManager database paths to start-sagemaker-ui-jupyter-server script in order to fix the SQLLite read only error causing files to not open in SMD 2.9 with jupyter-collaboration. This change adds these paths to v2 template

## Description
[Provide a brief description of the changes]

## Type of Change
- [X] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [X] Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]

## How Has This Been Tested?
[Describe the tests you ran]

## Checklist:
- [X] My code follows the style guidelines of this project
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [N/A] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
[Link any related issues here]

## Additional Notes
[Any additional information that might be helpful for reviewers]
