### PR TITLE
Fix micromamba package removal in SMD 3.x:

### DIFF
--- a/build_artifacts/v3/v3.3/v3.3.2/dirs/usr/local/bin/start-jupyter-server
+++ b/build_artifacts/v3/v3.3/v3.3.2/dirs/usr/local/bin/start-jupyter-server
@@ -11,7 +11,7 @@ else
     # Activate conda environment 'base'
     micromamba activate base
     # Uninstall SMUS-specific extensions
-    micromamba remove -y --no-prune sagemaker-studio-dataengineering-sessions sagemaker-studio-dataengineering-extensions
+    micromamba remove -y sagemaker-studio-dataengineering-sessions sagemaker-studio-dataengineering-extensions
     # Disable SMUS-specific extensions
     jupyter labextension disable sagemaker-data-explorer:plugin
 fi

--- a/build_artifacts/v3/v3.4/v3.4.2/dirs/usr/local/bin/start-jupyter-server
+++ b/build_artifacts/v3/v3.4/v3.4.2/dirs/usr/local/bin/start-jupyter-server
@@ -11,7 +11,7 @@ else
     # Activate conda environment 'base'
     micromamba activate base
     # Uninstall SMUS-specific extensions
-    micromamba remove -y --no-prune sagemaker-studio-dataengineering-sessions sagemaker-studio-dataengineering-extensions
+    micromamba remove -y sagemaker-studio-dataengineering-sessions sagemaker-studio-dataengineering-extensions
     # Disable SMUS-specific extensions
     jupyter labextension disable sagemaker-data-explorer:plugin @amzn/sagemaker_gen_ai_jupyterlab_extension
 fi

--- a/template/v3/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v3/dirs/usr/local/bin/start-jupyter-server
@@ -11,7 +11,7 @@ else
     # Activate conda environment 'base'
     micromamba activate base
     # Uninstall SMUS-specific extensions
-    micromamba remove -y --no-prune sagemaker-studio-dataengineering-sessions sagemaker-studio-dataengineering-extensions
+    micromamba remove -y sagemaker-studio-dataengineering-sessions sagemaker-studio-dataengineering-extensions
     # Disable SMUS-specific extensions
     jupyter labextension disable sagemaker-data-explorer:plugin @amzn/sagemaker_gen_ai_jupyterlab_extension
 fi


### PR DESCRIPTION
## Description
Fix micromamba package removal in SMD 3.x:
- Remove --no-prune flag which was deprecated in micromamba 2.x
- Use default removal behavior which now intelligently preserves shared dependencies


## Type of Change
- [X] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [X] Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
AI Studio 3.x startup fails without micromamba fix

## How Has This Been Tested?
Pull SMD image to local and replace /usr/local/bin/start-jupyter-server with new version

```
docker cp /sagemaker-distribution/build_artifacts/v3/v3/v3.4.2/dirs/usr/local/bin/start-jupyter-server sleepy_curie:/usr/local/bin/start-jupyter-server
```

Then execute start-jupyter-server command manually

```
docker exec -it sleepy_curie /usr/local/bin/start-jupyter-server
```

Execute log
```
Transaction

  Prefix: /opt/conda

  Removing specs:

   - sagemaker-studio-dataengineering-sessions
   - sagemaker-studio-dataengineering-extensions


  Package                                        Version  Build         Channel          Size
───────────────────────────────────────────────────────────────────────────────────────────────
  Remove:
───────────────────────────────────────────────────────────────────────────────────────────────

  - sagemaker-studio-dataengineering-extensions    1.1.2  pyh80e38bb_0  conda-forge       1MB
  - sagemaker-studio-dataengineering-sessions      1.1.2  pyhd8ed1ab_0  conda-forge     167kB

  Summary:

  Remove: 2 packages

  Total download: 0 B

───────────────────────────────────────────────────────────────────────────────────────────────



Transaction starting
Unlinking sagemaker-studio-dataengineering-extensions-1.1.2-pyh80e38bb_0
Unlinking sagemaker-studio-dataengineering-sessions-1.1.2-pyhd8ed1ab_0

Transaction finished

Starting with JupyterLab 4.1 individual plugins can be re-enabled in the user interface. While all plugins which were previously disabled have been locked, you need to explicitly lock any newly disabled plugins by using `jupyter labextension lock` command.
[W 2025-09-13 00:15:35.274 ServerApp] ServerApp.token config is deprecated in 2.0. Use IdentityProvider.token.
/opt/conda/lib/python3.12/site-packages/snowflake/connector/options.py:104: UserWarning: You have an incompatible version of 'pyarrow' installed (19.0.1), please install a version that adheres to: 'pyarrow<19.0.0; extra == "pandas"'
  warn_incompatible_dep(
INFO:traitlets:Extension package amazon_sagemaker_jupyter_ai_q_developer took 0.2574s to import
[I 2025-09-13 00:15:38.702 SagemakerQChatExtension] Q Dev Chat API Logger Initialized and logs in - /var/log/studio/q_dev_chat/q_dev_chat_api.log,q-dev-chat-api-operations
[I 2025-09-13 00:15:38.702 SageMakerSchedulingApp] API file handler Location - /home/sagemaker-user/.sagemaker/sagemaker-scheduler.api.log
WARNING:traitlets:A `_jupyter_server_extension_points` function was not found in jupyter_activity_monitor_extension. Instead, a `_jupyter_server_extension_paths` function was found and will be used for now. This function name will be deprecated in future releases of Jupyter Server.
INFO:traitlets:Extension package jupyter_ai took 0.1833s to import
INFO:traitlets:Extension package panel.io.jupyter_server_extension took 0.3933s to import
[I 2025-09-13 00:15:39.376 ServerApp] amazon_q_developer_jupyterlab_ext | extension was successfully linked.
[I 2025-09-13 00:15:39.378 ServerApp] amazon_sagemaker_jupyter_ai_q_developer | extension was successfully linked.
[I 2025-09-13 00:15:39.380 ServerApp] amazon_sagemaker_jupyter_scheduler | extension was successfully linked.
[I 2025-09-13 00:15:39.382 ServerApp] amazon_sagemaker_sql_editor | extension was successfully linked.
[I 2025-09-13 00:15:39.382 ServerApp] amzn_sagemaker_aiops_jupyterlab_extension | extension was successfully linked.
[I 2025-09-13 00:15:39.382 ServerApp] jupyter_activity_monitor_extension | extension was successfully linked.
[I 2025-09-13 00:15:39.384 ServerApp] jupyter_ai | extension was successfully linked.
[I 2025-09-13 00:15:39.384 ServerApp] jupyter_lsp | extension was successfully linked.
[I 2025-09-13 00:15:39.385 ServerApp] jupyter_scheduler | extension was successfully linked.
[I 2025-09-13 00:15:39.387 ServerApp] jupyter_server_fileid | extension was successfully linked.
[I 2025-09-13 00:15:39.389 ServerApp] jupyter_server_mathjax | extension was successfully linked.
[I 2025-09-13 00:15:39.389 ServerApp] jupyter_server_proxy | extension was successfully linked.
[I 2025-09-13 00:15:39.391 ServerApp] jupyter_server_terminals | extension was successfully linked.
[I 2025-09-13 00:15:39.392 ServerApp] jupyter_server_ydoc | extension was successfully linked.
[I 2025-09-13 00:15:39.395 ServerApp] jupyterlab | extension was successfully linked.
[I 2025-09-13 00:15:39.395 ServerApp] jupyterlab_git | extension was successfully linked.
[I 2025-09-13 00:15:39.395 ServerApp] nbdime | extension was successfully linked.
[I 2025-09-13 00:15:39.397 ServerApp] notebook | extension was successfully linked.
[I 2025-09-13 00:15:39.517 ServerApp] notebook_shim | extension was successfully linked.
[I 2025-09-13 00:15:39.518 ServerApp] panel.io.jupyter_server_extension | extension was successfully linked.
[I 2025-09-13 00:15:39.518 ServerApp] sagemaker_jupyterlab_emr_extension | extension was successfully linked.
[I 2025-09-13 00:15:39.518 ServerApp] sagemaker_jupyterlab_extension | extension was successfully linked.
[I 2025-09-13 00:15:39.518 ServerApp] sagemaker_jupyterlab_extension_common | extension was successfully linked.
[I 2025-09-13 00:15:39.526 ServerApp] notebook_shim | extension was successfully loaded.
[I 2025-09-13 00:15:39.527 ServerApp] Registered amazon_q_developer_jupyterlab_ext extension at URL path /amazon_q_developer_jupyterlab_ext
[I 2025-09-13 00:15:39.527 ServerApp] amazon_q_developer_jupyterlab_ext | extension was successfully loaded.
[I 2025-09-13 00:15:39.527 ServerApp] amazon_sagemaker_jupyter_ai_q_developer | extension was successfully loaded.
[I 2025-09-13 00:15:39.527 ServerApp] amazon_sagemaker_jupyter_scheduler | extension was successfully loaded.
[I 2025-09-13 00:15:39.527 ServerApp] amazon_sagemaker_sql_editor | extension was successfully loaded.
[I 2025-09-13 00:15:39.527 ServerApp] Loading SageMaker JupyterLab server extension 1.0.4
[I 2025-09-13 00:15:39.527 ServerApp] Registering handlers for amzn_sagemaker_aiops_jupyterlab_extension
[I 2025-09-13 00:15:39.527 ServerApp] Base URL: /
[I 2025-09-13 00:15:39.528 ServerApp] amzn_sagemaker_aiops_jupyterlab_extension | extension was successfully loaded.
[I 2025-09-13 00:15:39.528 ServerApp] jupyter_activity_monitor_extension | extension was successfully loaded.
[I 2025-09-13 00:15:39.528 AiExtension] Configured provider allowlist: None
[I 2025-09-13 00:15:39.528 AiExtension] Configured provider blocklist: None
[I 2025-09-13 00:15:39.528 AiExtension] Configured model allowlist: None
[I 2025-09-13 00:15:39.528 AiExtension] Configured model blocklist: None
[I 2025-09-13 00:15:39.528 AiExtension] Configured model parameters: {}
[I 2025-09-13 00:15:39.542 AiExtension] Registered model provider `amazon-q`.
[I 2025-09-13 00:15:39.542 AiExtension] Registered model provider `ai21`.
[I 2025-09-13 00:15:39.583 AiExtension] Registered model provider `bedrock`.
[I 2025-09-13 00:15:39.583 AiExtension] Registered model provider `bedrock-chat`.
[I 2025-09-13 00:15:39.583 AiExtension] Registered model provider `bedrock-custom`.
[W 2025-09-13 00:15:39.583 AiExtension] Unable to load model provider `anthropic-chat`. Please install the `langchain_anthropic` package.
[W 2025-09-13 00:15:39.583 AiExtension] Unable to load model provider `azure-chat-openai`. Please install the `langchain_openai` package.
[W 2025-09-13 00:15:39.583 AiExtension] Unable to load model provider `cohere`. Please install the `langchain_cohere` package.
[W 2025-09-13 00:15:39.584 AiExtension] Unable to load model provider `gemini`. Please install the `langchain_google_genai` package.
[I 2025-09-13 00:15:39.584 AiExtension] Registered model provider `gpt4all`.
[I 2025-09-13 00:15:39.584 AiExtension] Registered model provider `huggingface_hub`.
[W 2025-09-13 00:15:39.584 AiExtension] Unable to load model provider `mistralai`. Please install the `langchain_mistralai` package.
[W 2025-09-13 00:15:39.584 AiExtension] Unable to load model provider `nvidia-chat`. Please install the `langchain_nvidia_ai_endpoints` package.
[W 2025-09-13 00:15:39.584 AiExtension] Unable to load model provider `ollama`. Please install the `langchain_ollama` package.
[W 2025-09-13 00:15:39.585 AiExtension] Unable to load model provider `openai`. Please install the `langchain_openai` package.
[W 2025-09-13 00:15:39.585 AiExtension] Unable to load model provider `openai-chat`. Please install the `langchain_openai` package.
[W 2025-09-13 00:15:39.585 AiExtension] Unable to load model provider `openai-chat-custom`. Please install the `langchain_openai` package.
[W 2025-09-13 00:15:39.585 AiExtension] Unable to load model provider `openrouter`. Please install the `langchain_openai` package.
[I 2025-09-13 00:15:39.585 AiExtension] Registered model provider `qianfan`.
[I 2025-09-13 00:15:39.585 AiExtension] Registered model provider `sagemaker-endpoint`.
[I 2025-09-13 00:15:39.585 AiExtension] Registered model provider `togetherai`.
[I 2025-09-13 00:15:39.600 AiExtension] Registered embeddings model provider `codesage`.
[W 2025-09-13 00:15:39.600 AiExtension] Unable to load embeddings model provider class from entry point `azure`: No module named 'langchain_openai'.
[I 2025-09-13 00:15:39.601 AiExtension] Registered embeddings model provider `bedrock`.
[W 2025-09-13 00:15:39.601 AiExtension] Unable to load embeddings model provider class from entry point `cohere`: No module named 'langchain_cohere'.
[I 2025-09-13 00:15:39.601 AiExtension] Registered embeddings model provider `gpt4all`.
[I 2025-09-13 00:15:39.601 AiExtension] Registered embeddings model provider `huggingface_hub`.
[W 2025-09-13 00:15:39.601 AiExtension] Unable to load embeddings model provider class from entry point `mistralai`: No module named 'langchain_mistralai'.
[W 2025-09-13 00:15:39.601 AiExtension] Unable to load embeddings model provider class from entry point `ollama`: No module named 'langchain_ollama'.
[W 2025-09-13 00:15:39.602 AiExtension] Unable to load embeddings model provider class from entry point `openai`: No module named 'langchain_openai'.
[W 2025-09-13 00:15:39.602 AiExtension] Unable to load embeddings model provider class from entry point `openai-custom`: No module named 'langchain_openai'.
[I 2025-09-13 00:15:39.602 AiExtension] Registered embeddings model provider `qianfan`.
[I 2025-09-13 00:15:39.609 AiExtension] Registered providers.
[I 2025-09-13 00:15:39.609 AiExtension] Registered jupyter_ai server extension
[I 2025-09-13 00:15:39.627 AiExtension] Registered chat handler `ask` with command `/ask`.
[I 2025-09-13 00:15:39.628 AiExtension] Registered chat handler `clear` with command `/clear`.
[I 2025-09-13 00:15:39.628 AiExtension] Registered chat handler `default` with command `default`.
[I 2025-09-13 00:15:39.628 AiExtension] Registered chat handler `export` with command `/export`.
[I 2025-09-13 00:15:39.628 AiExtension] Registered chat handler `fix` with command `/fix`.
[I 2025-09-13 00:15:39.628 AiExtension] Registered chat handler `generate` with command `/generate`.
[I 2025-09-13 00:15:39.628 AiExtension] Registered chat handler `help` with command `/help`.
[I 2025-09-13 00:15:39.629 AiExtension] No existing vector index found. You may create one using `/learn`.
[I 2025-09-13 00:15:39.629 AiExtension] Registered chat handler `learn` with command `/learn`.
[I 2025-09-13 00:15:39.630 AiExtension] Registered chat handler `explain` with command `/explain`.
[I 2025-09-13 00:15:39.630 AiExtension] Registered chat handler `optimize` with command `/optimize`.
[I 2025-09-13 00:15:39.630 AiExtension] Registered chat handler `refactor` with command `/refactor`.
[I 2025-09-13 00:15:39.644 AiExtension] Registered context provider `file`.
[I 2025-09-13 00:15:39.645 AiExtension] Initialized Jupyter AI server extension in 117 ms.
[I 2025-09-13 00:15:39.646 ServerApp] jupyter_ai | extension was successfully loaded.
[I 2025-09-13 00:15:39.647 ServerApp] jupyter_lsp | extension was successfully loaded.
[I 2025-09-13 00:15:39.811 ServerApp] jupyter_scheduler | extension was successfully loaded.
[I 2025-09-13 00:15:39.811 FileIdExtension] Configured File ID manager: ArbitraryFileIdManager
[I 2025-09-13 00:15:39.811 FileIdExtension] ArbitraryFileIdManager : Configured root dir: /home/sagemaker-user
[I 2025-09-13 00:15:39.812 FileIdExtension] ArbitraryFileIdManager : Configured database path: /home/sagemaker-user/.local/share/jupyter/file_id_manager.db
[I 2025-09-13 00:15:39.813 FileIdExtension] ArbitraryFileIdManager : Successfully connected to database file.
[I 2025-09-13 00:15:39.813 FileIdExtension] ArbitraryFileIdManager : Creating File ID tables and indices with journal_mode = DELETE
[I 2025-09-13 00:15:39.813 FileIdExtension] Attached event listeners.
[I 2025-09-13 00:15:39.813 ServerApp] jupyter_server_fileid | extension was successfully loaded.
[I 2025-09-13 00:15:39.813 ServerApp] jupyter_server_mathjax | extension was successfully loaded.
[I 2025-09-13 00:15:39.828 ServerApp] jupyter_server_proxy | extension was successfully loaded.
[I 2025-09-13 00:15:39.828 ServerApp] jupyter_server_terminals | extension was successfully loaded.
/opt/conda/lib/python3.12/site-packages/jupyter_events/schema.py:68: JupyterEventsVersionWarning: The `version` property of an event schema must be a string. It has been type coerced, but in a future version of this library, it will fail to validate. Please update schema: https://schema.jupyter.org/jupyter_collaboration/session/v1
  validate_schema(_schema)
/opt/conda/lib/python3.12/site-packages/jupyter_events/schema.py:68: JupyterEventsVersionWarning: The `version` property of an event schema must be a string. It has been type coerced, but in a future version of this library, it will fail to validate. Please update schema: https://schema.jupyter.org/jupyter_collaboration/awareness/v1
  validate_schema(_schema)
/opt/conda/lib/python3.12/site-packages/jupyter_events/schema.py:68: JupyterEventsVersionWarning: The `version` property of an event schema must be a string. It has been type coerced, but in a future version of this library, it will fail to validate. Please update schema: https://schema.jupyter.org/jupyter_collaboration/fork/v1
  validate_schema(_schema)
[I 2025-09-13 00:15:39.831 ServerApp] jupyter_server_ydoc | extension was successfully loaded.
[I 2025-09-13 00:15:39.834 LabApp] JupyterLab extension loaded from /opt/conda/lib/python3.12/site-packages/jupyterlab
[I 2025-09-13 00:15:39.834 LabApp] JupyterLab application directory is /opt/conda/share/jupyter/lab
[I 2025-09-13 00:15:39.834 LabApp] Extension Manager is 'pypi'.
[I 2025-09-13 00:15:39.860 ServerApp] jupyterlab | extension was successfully loaded.
[I 2025-09-13 00:15:39.862 ServerApp] jupyterlab_git | extension was successfully loaded.
[I 2025-09-13 00:15:39.916 ServerApp] nbdime | extension was successfully loaded.
[I 2025-09-13 00:15:39.919 ServerApp] notebook | extension was successfully loaded.
[I 2025-09-13 00:15:39.920 ServerApp] panel.io.jupyter_server_extension | extension was successfully loaded.
[I 2025-09-13 00:15:39.920 ServerApp] Loading SageMaker Studio EMR server extension 0.4.0
[I 2025-09-13 00:15:39.920 ServerApp] sagemaker_jupyterlab_emr_extension | extension was successfully loaded.
[I 2025-09-13 00:15:39.920 ServerApp] Loading SageMaker JupyterLab server extension 0.5.0
[I 2025-09-13 00:15:39.921 ServerApp] sagemaker_jupyterlab_extension | extension was successfully loaded.
[I 2025-09-13 00:15:39.921 ServerApp] Loading SageMaker JupyterLab common server extension 0.2.6
[I 2025-09-13 00:15:39.921 ServerApp] sagemaker_jupyterlab_extension_common | extension was successfully loaded.
[I 2025-09-13 00:15:39.922 ServerApp] The port 8888 is already in use, trying another port.
[I 2025-09-13 00:15:39.923 ServerApp] Serving notebooks from local directory: /home/sagemaker-user
[I 2025-09-13 00:15:39.923 ServerApp] Jupyter Server 2.16.0 is running at:
[I 2025-09-13 00:15:39.923 ServerApp] http://be8de2563228:8889/lab
[I 2025-09-13 00:15:39.923 ServerApp]     http://127.0.0.1:8889/lab
[I 2025-09-13 00:15:39.923 ServerApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
[W 2025-09-13 00:15:39.926 ServerApp] No web browser found: Error('could not locate runnable browser').
/opt/conda/lib/python3.12/site-packages/distributed/node.py:187: UserWarning: Port 8787 is already in use.
Perhaps you already have a cluster running?
Hosting the HTTP server on port 40105 instead
  warnings.warn(
INFO:distributed.scheduler:State start
INFO:distributed.scheduler:  Scheduler at: inproc://172.17.0.2/153/1
INFO:distributed.scheduler:  dashboard at:  http://172.17.0.2:40105/status
INFO:distributed.scheduler:Registering Worker plugin shuffle
INFO:distributed.worker:      Start worker at:  inproc://172.17.0.2/153/4
INFO:distributed.worker:         Listening to:           inproc172.17.0.2
INFO:distributed.worker:          Worker name:                          0
INFO:distributed.worker:         dashboard at:           172.17.0.2:36829
INFO:distributed.worker:Waiting to connect to:  inproc://172.17.0.2/153/1
INFO:distributed.worker:-------------------------------------------------
INFO:distributed.worker:              Threads:                         14
INFO:distributed.worker:               Memory:                   7.65 GiB
INFO:distributed.worker:      Local Directory: /tmp/dask-scratch-space/worker-_wuxpyrq
INFO:distributed.worker:-------------------------------------------------
INFO:distributed.scheduler:Register worker addr: inproc://172.17.0.2/153/4 name: 0
INFO:distributed.scheduler:Starting worker compute stream, inproc://172.17.0.2/153/4
INFO:distributed.core:Starting established connection to inproc://172.17.0.2/153/5
INFO:distributed.worker:Starting Worker plugin shuffle
INFO:distributed.worker:        Registered to:  inproc://172.17.0.2/153/1
INFO:distributed.worker:-------------------------------------------------
INFO:distributed.core:Starting established connection to inproc://172.17.0.2/153/1
INFO:distributed.scheduler:Receive client connection: Client-c790c13e-9036-11f0-8099-26ca4cbca035
INFO:distributed.core:Starting established connection to inproc://172.17.0.2/153/6
[I 2025-09-13 00:15:40.494 ServerApp] Skipped non-installed server(s): bash-language-server, dockerfile-language-server-nodejs, javascript-typescript-langserver, jedi-language-server, julia-language-server, pyright, python-language-server, r-languageserver, texlab, typescript-language-server, unified-language-server, vscode-css-languageserver-bin, vscode-html-languageserver-bin, vscode-json-languageserver-bin, yaml-language-server
```

## Checklist:
- [X] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):
<img width="706" height="397" alt="Screenshot 2025-09-12 at 5 16 40 PM" src="https://github.com/user-attachments/assets/3dafc498-a716-4983-ad48-3e02244434b9" />

<img width="956" height="330" alt="Screenshot 2025-09-12 at 5 17 00 PM" src="https://github.com/user-attachments/assets/553c49dc-d24a-4f41-889f-36ac5c955077" />

## Related Issues
[Link any related issues here]

## Additional Notes
[Any additional information that might be helpful for reviewers]
