### PR TITLE
Fix RTC for SMD v3 by enabling docprovider extension in shared spaces

### DIFF
--- a/build_artifacts/v3/v3.1/v3.1.2/dirs/usr/local/bin/start-jupyter-server
+++ b/build_artifacts/v3/v3.1/v3.1.2/dirs/usr/local/bin/start-jupyter-server
@@ -16,6 +16,7 @@ fi
 # Start Jupyter server in rtc mode for shared spaces
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ]; then
   jupyter labextension enable @jupyter/collaboration-extension
+  jupyter labextension enable @jupyter/docprovider-extension
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   # SAGEMAKER_SPACE_TYPE_LOWERCASE flag is used to determine if the server should start

--- a/build_artifacts/v3/v3.2/v3.2.2/dirs/usr/local/bin/start-jupyter-server
+++ b/build_artifacts/v3/v3.2/v3.2.2/dirs/usr/local/bin/start-jupyter-server
@@ -16,6 +16,7 @@ fi
 # Start Jupyter server in rtc mode for shared spaces
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ]; then
   jupyter labextension enable @jupyter/collaboration-extension
+  jupyter labextension enable @jupyter/docprovider-extension
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   # SAGEMAKER_SPACE_TYPE_LOWERCASE flag is used to determine if the server should start

--- a/build_artifacts/v3/v3.3/v3.3.3/dirs/usr/local/bin/start-jupyter-server
+++ b/build_artifacts/v3/v3.3/v3.3.3/dirs/usr/local/bin/start-jupyter-server
@@ -19,6 +19,7 @@ fi
 # Start Jupyter server in rtc mode for shared spaces
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ]; then
   jupyter labextension enable @jupyter/collaboration-extension
+  jupyter labextension enable @jupyter/docprovider-extension
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   # SAGEMAKER_SPACE_TYPE_LOWERCASE flag is used to determine if the server should start

--- a/build_artifacts/v3/v3.4/v3.4.3/dirs/usr/local/bin/start-jupyter-server
+++ b/build_artifacts/v3/v3.4/v3.4.3/dirs/usr/local/bin/start-jupyter-server
@@ -19,6 +19,7 @@ fi
 # Start Jupyter server in rtc mode for shared spaces
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ]; then
   jupyter labextension enable @jupyter/collaboration-extension
+  jupyter labextension enable @jupyter/docprovider-extension
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   # SAGEMAKER_SPACE_TYPE_LOWERCASE flag is used to determine if the server should start

--- a/template/v3/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v3/dirs/usr/local/bin/start-jupyter-server
@@ -19,6 +19,7 @@ fi
 # Start Jupyter server in rtc mode for shared spaces
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ]; then
   jupyter labextension enable @jupyter/collaboration-extension
+  jupyter labextension enable @jupyter/docprovider-extension
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   # SAGEMAKER_SPACE_TYPE_LOWERCASE flag is used to determine if the server should start


### PR DESCRIPTION
- Fix RTC for SMD v3 by enabling docprovider extension in shared spaces

## Description
SMD v3.0.0 has broken Jupyter Real Time Collaboration that allows for real-time inline active editing. This contains fix.

## Type of Change
- [x] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [x] Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
Customers expect RTC To be functional.

## How Has This Been Tested?
Tested by running `jupyter labextension enable @jupyter/docprovider-extension`. Full image build has not been tested

## Checklist:
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

