### PR TITLE
Updated CodeEditor entrypoint script for SageMaker's recovery mode

### DIFF
--- a/template/v3/dirs/usr/local/bin/start-code-editor
+++ b/template/v3/dirs/usr/local/bin/start-code-editor
@@ -6,6 +6,8 @@ EBS_MOUNT_POINT="/home/sagemaker-user"
 
 persistent_settings_folder="${EBS_MOUNT_POINT}/sagemaker-code-editor-server-data"
 default_settings_folder="${EFS_MOUNT_POINT}/sagemaker-code-editor-server-data"
+# SAGEMAKER_RECOVERY_MODE_HOME env variable is set in Dockerfile
+recovery_mode_settings_folder="${SAGEMAKER_RECOVERY_MODE_HOME}/sagemaker-code-editor-server-data"
 
 override_machine_settings() {
   # create a new settings file with preset defaults or merge the defaults into the existing settings file
@@ -65,16 +67,33 @@ micromamba activate base
 # Start code-editor server
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker app.
-  override_machine_settings
-  copy_user_settings
-  install_prepackaged_extensions
-  # Configure the base url to be `/<app-type-in-lower-case>/default`.
-  sagemaker-code-editor --host 0.0.0.0 --port 8888 \
-    --without-connection-token \
-    --base-path "/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
-    --server-data-dir $persistent_settings_folder \
-    --extensions-dir ${persistent_settings_folder}/extensions \
-    --user-data-dir /opt/amazon/sagemaker/sagemaker-code-editor-user-data
+  if [ -n "$SAGEMAKER_RECOVERY_MODE" ]; then
+    # SAGEMAKER_RECOVERY_MODE is set, indicating the SageMaker app is running in recovery mode
+    export HOME=$SAGEMAKER_RECOVERY_MODE_HOME
+    
+    # Create recovery mode directories and set ownership
+    mkdir -p $recovery_mode_settings_folder ${recovery_mode_settings_folder}/extensions
+    chown -R $MAMBA_USER:$MAMBA_USER $recovery_mode_settings_folder
+    
+    # Configure the base url to be `/<app-type-in-lower-case>/default` and use clean temporary directories in recovery mode
+    sagemaker-code-editor --host 0.0.0.0 --port 8888 \
+      --without-connection-token \
+      --base-path "/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
+      --server-data-dir $recovery_mode_settings_folder \
+      --extensions-dir ${recovery_mode_settings_folder}/extensions \
+      --user-data-dir /opt/amazon/sagemaker/sagemaker-code-editor-user-data
+  else
+    override_machine_settings
+    copy_user_settings
+    install_prepackaged_extensions
+    # Configure the base url to be `/<app-type-in-lower-case>/default`
+    sagemaker-code-editor --host 0.0.0.0 --port 8888 \
+      --without-connection-token \
+      --base-path "/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
+      --server-data-dir $persistent_settings_folder \
+      --extensions-dir ${persistent_settings_folder}/extensions \
+      --user-data-dir /opt/amazon/sagemaker/sagemaker-code-editor-user-data
+  fi
 else
   sagemaker-code-editor --host 0.0.0.0 --port 8888 \
     --without-connection-token \


### PR DESCRIPTION
## Description
This PR adds changes needed to support recovery mode for CodeEditor. 
In recovery mode, we need to not utilizing the standard mode home directory `/home/sagemaker-user`

This PR updates it to use temp clean folders `/tmp/sagemaker-recovery-mode-home` and does not include any settings merge logic

## Type of Change
- [X] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ ] Yes (Critical bug fix or security update)
- [X] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]

## How Has This Been Tested?
Built a new image as follows 
- latest SMD as base 
- modified the entrypoint file `start-code-editor` as per this PR
- set SAGEMAKER_RECOVERY_MODE env var to true to mimic recovery mode

Verified that server starts fine with expected tmp folders and no errors

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
[Link any related issues here]

## Additional Notes
[Any additional information that might be helpful for reviewers]
