### PR TITLE
fix race condition vulnerability in build-image workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -89,7 +89,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # Create PR if it doesn't exist; fetch existing PR number if it does
         run: |
-          if gh pr list --head release-${{ steps.calc_target.outputs.target_version }} --state open --json number | grep -q '"number":'; then
+          if gh pr list --head release-${{ steps.calc_target.outputs.target_version }} --author "app/github-actions"
+          --state open --json number | grep -q '"number":'; then
             echo "PR exists already, just fetching ID"
             PR_ID=$(gh pr view release-${{ steps.calc_target.outputs.target_version }} --json number | jq -r .number)
             echo "pr_id=$PR_ID" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Add --author 'app/github-actions' flag to gh pr list command to prevent attackers from creating malicious PRs with matching head branch names that could be selected by the workflow instead of trusted bot-created PRs.

This prevents remote code execution via malicious PR injection during the release process.

## Description
[Provide a brief description of the changes]

## Type of Change
- [ ] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [x] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ ] Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [x] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]

## How Has This Been Tested?
[Describe the tests you ran]

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
[Link any related issues here]

## Additional Notes
[Any additional information that might be helpful for reviewers]
