### PR TITLE
chore: update q extension version to use credential refresh fix

### DIFF
--- a/template/v2/dirs/etc/code-editor/extensions.txt
+++ b/template/v2/dirs/etc/code-editor/extensions.txt
@@ -1,4 +1,4 @@
 https://open-vsx.org/api/ms-toolsai/jupyter/2024.5.0/file/ms-toolsai.jupyter-2024.5.0.vsix
 https://open-vsx.org/api/ms-python/python/2023.20.0/file/ms-python.python-2023.20.0.vsix
 https://open-vsx.org/api/amazonwebservices/aws-toolkit-vscode/3.69.0/file/amazonwebservices.aws-toolkit-vscode-3.69.0.vsix
-https://open-vsx.org/api/amazonwebservices/amazon-q-vscode/1.90.0/file/amazonwebservices.amazon-q-vscode-1.90.0.vsix
+https://open-vsx.org/api/amazonwebservices/amazon-q-vscode/1.97.0/file/amazonwebservices.amazon-q-vscode-1.97.0.vsix

--- a/template/v3/dirs/etc/code-editor/extensions.txt
+++ b/template/v3/dirs/etc/code-editor/extensions.txt
@@ -1,4 +1,4 @@
 https://open-vsx.org/api/ms-toolsai/jupyter/2024.5.0/file/ms-toolsai.jupyter-2024.5.0.vsix
 https://open-vsx.org/api/ms-python/python/2023.20.0/file/ms-python.python-2023.20.0.vsix
 https://open-vsx.org/api/amazonwebservices/aws-toolkit-vscode/3.69.0/file/amazonwebservices.aws-toolkit-vscode-3.69.0.vsix
-https://open-vsx.org/api/amazonwebservices/amazon-q-vscode/1.90.0/file/amazonwebservices.amazon-q-vscode-1.90.0.vsix
+https://open-vsx.org/api/amazonwebservices/amazon-q-vscode/1.97.0/file/amazonwebservices.amazon-q-vscode-1.97.0.vsix


### PR DESCRIPTION
## Description
- Update Q extension version being used in `v2 and v3 SMD` versions to use the latest `1.97 version` which has fix for missing credential expiration field to enable refresh properly
- Corresponding flare side change is already released [flare server side](https://aws-toolkit-language-servers.amazonaws.com/qAgenticChatServer/0/manifest.json) as part of `1.37 version`

## Type of Change
- [ ] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ ] Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]

## How Has This Been Tested?
[Describe the tests you ran]

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
[Link any related issues here]

## Additional Notes
[Any additional information that might be helpful for reviewers]
