### PR TITLE
Handle Amazon Q Agentic Chat artifacts and build improvements

### DIFF
--- a/assets/get_amazon_q_agentic_chat_artifacts.py
+++ b/assets/get_amazon_q_agentic_chat_artifacts.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Extract Amazon Q artifact URLs from manifest for Linux x64 platform."""
+
+import json
+import sys
+
+def extract_urls(manifest_file, version, platform='linux', arch='x64'):
+    """Extract servers.zip and clients.zip URLs for specified platform/arch."""
+    with open(manifest_file) as f:
+        manifest = json.load(f)
+    
+    for ver in manifest['versions']:
+        if ver['serverVersion'] == version:
+            for target in ver['targets']:
+                if target['platform'] == platform and target.get('arch') == arch:
+                    servers_url = None
+                    clients_url = None
+                    
+                    for content in target['contents']:
+                        if content['filename'] == 'servers.zip':
+                            servers_url = content['url']
+                        elif content['filename'] == 'clients.zip':
+                            clients_url = content['url']
+                    
+                    return servers_url, clients_url
+    
+    raise ValueError(f"Version {version} not found for {platform} {arch}")
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3:
+        print("Usage: get_amazon_q_agentic_chat_artifacts.py <manifest_file> <version>")
+        sys.exit(1)
+    
+    manifest_file, version = sys.argv[1], sys.argv[2]
+    servers_url, clients_url = extract_urls(manifest_file, version)
+    
+    print(f"SERVERS_URL={servers_url}")
+    print(f"CLIENTS_URL={clients_url}")

--- a/src/main.py
+++ b/src/main.py
@@ -131,6 +131,11 @@ def _copy_static_files(base_version_dir, new_version_dir, new_version_major, run
     if os.path.exists(aws_cli_key_path):
         shutil.copy2(aws_cli_key_path, new_version_dir)
 
+    # Copy Amazon Q artifacts script from assets
+    q_artifacts_script_path = os.path.relpath(f"assets/get_amazon_q_agentic_chat_artifacts.py")
+    if os.path.exists(q_artifacts_script_path):
+        shutil.copy2(q_artifacts_script_path, new_version_dir)
+
     if int(new_version_major) >= 1:
         # dirs directory doesn't exist for v0. It was introduced only for v1
         dirs_relative_path = os.path.relpath(f"{base_path}/dirs")

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,7 +1,7 @@
 import json
 import os
+import subprocess
 
-import conda.cli.python_api
 from conda.env.specs import RequirementsSpec
 from conda.exceptions import PackagesNotFoundError
 from conda.models.match_spec import MatchSpec
@@ -106,9 +106,14 @@ def pull_conda_package_metadata(image_config, image_artifact_dir):
         if str(match_spec_out).startswith("conda-forge"):
             # Pull package metadata from conda-forge and dump into json file
             try:
-                search_result = conda.cli.python_api.run_command("search", str(match_spec_out), "--json")
-                package_metadata = json.loads(search_result[0])[package][0]
+                search_result = subprocess.run(["conda", "search", str(match_spec_out), "--json"], 
+                                             capture_output=True, text=True, check=True)
+                package_metadata = json.loads(search_result.stdout)[package][0]
                 results[package] = {"version": package_metadata["version"], "size": package_metadata["size"]}
+            except (subprocess.CalledProcessError, json.JSONDecodeError, KeyError, IndexError) as e:
+                print(
+                    f"Failed to pull package metadata for {package}, {match_spec_out} from conda-forge, ignore. Error: {str(e)}"
+                )
             except PackagesNotFoundError:
                 print(
                     f"Failed to pull package metadata for {package}, {match_spec_out} from conda-forge, ignore. Potentially this package is broken."

--- a/template/v2/Dockerfile
+++ b/template/v2/Dockerfile
@@ -49,6 +49,7 @@ ENV MAMBA_USER=$NB_USER
 ENV USER=$NB_USER
 
 COPY aws-cli-public-key.asc /tmp/
+COPY get_amazon_q_agentic_chat_artifacts.py /tmp/
 
 RUN apt-get update && apt-get upgrade -y && \
     apt-get install -y --no-install-recommends sudo gettext-base wget curl unzip git rsync build-essential openssh-client nano cron less mandoc jq ca-certificates gnupg && \
@@ -73,7 +74,6 @@ RUN apt-get update && apt-get upgrade -y && \
     unzip q.zip && \
     Q_INSTALL_GLOBAL=true ./q/install.sh --no-confirm && \
     rm -rf q q.zip && \
-    : && \
     echo "source /usr/local/bin/_activate_current_env.sh" | tee --append /etc/profile && \
 # CodeEditor - create server, user data dirs
     mkdir -p /opt/amazon/sagemaker/sagemaker-code-editor-server-data /opt/amazon/sagemaker/sagemaker-code-editor-user-data \
@@ -121,6 +121,28 @@ RUN if [[ -z $ARG_BASED_ENV_IN_FILENAME ]] ; \
     find /opt/conda -name "yarn.lock" -type f -delete && \
     rm -rf /tmp/*.in && \
     sudo ln -s $(which python3) /usr/bin/python && \
+    # Download Amazon Q artifacts for JupyterLab extension
+    sudo mkdir -p /etc/amazon-q/artifacts/agentic-chat && \
+    # Download JSZip library
+    sudo curl -L "https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js" -o "/etc/amazon-q/artifacts/agentic-chat/jszip.min.js" && \
+    # Download and extract Amazon Q server and client artifacts
+    MANIFEST_URL="https://aws-toolkit-language-servers.amazonaws.com/qAgenticChatServer/0/manifest.json" && \
+    FLARE_SERVER_VERSION="1.25.0" && \
+    curl -L "$MANIFEST_URL" -o "/tmp/manifest.json" && \
+    # Extract artifact URLs using helper script
+    ARTIFACT_URLS=$(python3 /tmp/get_amazon_q_agentic_chat_artifacts.py /tmp/manifest.json $FLARE_SERVER_VERSION) && \
+    if [ $? -ne 0 ] || [ -z "$ARTIFACT_URLS" ]; then echo "Failed to extract Amazon Q artifact URLs" && exit 1; fi && \
+    eval $ARTIFACT_URLS && \
+    # Download and extract servers.zip
+    curl -L "$SERVERS_URL" -o "/tmp/servers.zip" && \
+    sudo unzip "/tmp/servers.zip" -d "/etc/amazon-q/artifacts/agentic-chat/servers" && \
+    # Download and extract clients.zip
+    curl -L "$CLIENTS_URL" -o "/tmp/clients.zip" && \
+    sudo unzip "/tmp/clients.zip" -d "/etc/amazon-q/artifacts/agentic-chat/clients" && \
+    # Clean up temporary files
+    rm -f /tmp/manifest.json /tmp/servers.zip /tmp/clients.zip && \
+    # Fix ownership for JupyterLab access
+    sudo chown -R $MAMBA_USER:$MAMBA_USER /etc/amazon-q/artifacts/ && \
     # Update npm version
     npm i -g npm && \
     # Enforce to use `conda-forge` as only channel, by removing `defaults`

--- a/template/v3/Dockerfile
+++ b/template/v3/Dockerfile
@@ -49,6 +49,7 @@ ENV MAMBA_USER=$NB_USER
 ENV USER=$NB_USER
 
 COPY aws-cli-public-key.asc /tmp/
+COPY get_amazon_q_agentic_chat_artifacts.py /tmp/
 
 RUN apt-get update && apt-get upgrade -y && \
     apt-get install -y --no-install-recommends sudo gettext-base wget curl unzip git rsync build-essential openssh-client nano cron less mandoc jq ca-certificates gnupg && \
@@ -73,7 +74,6 @@ RUN apt-get update && apt-get upgrade -y && \
     unzip q.zip && \
     Q_INSTALL_GLOBAL=true ./q/install.sh --no-confirm && \
     rm -rf q q.zip && \
-    : && \
     echo "source /usr/local/bin/_activate_current_env.sh" | tee --append /etc/profile && \
 # CodeEditor - create server, user data dirs
     mkdir -p /opt/amazon/sagemaker/sagemaker-code-editor-server-data /opt/amazon/sagemaker/sagemaker-code-editor-user-data \
@@ -121,6 +121,28 @@ RUN if [[ -z $ARG_BASED_ENV_IN_FILENAME ]] ; \
     find /opt/conda -name "yarn.lock" -type f -delete && \
     rm -rf /tmp/*.in && \
     sudo ln -s $(which python3) /usr/bin/python && \
+    # Download Amazon Q artifacts for JupyterLab extension
+    sudo mkdir -p /etc/amazon-q/artifacts/agentic-chat && \
+    # Download JSZip library
+    sudo curl -L "https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js" -o "/etc/amazon-q/artifacts/agentic-chat/jszip.min.js" && \
+    # Download and extract Amazon Q server and client artifacts
+    MANIFEST_URL="https://aws-toolkit-language-servers.amazonaws.com/qAgenticChatServer/0/manifest.json" && \
+    FLARE_SERVER_VERSION="1.25.0" && \
+    curl -L "$MANIFEST_URL" -o "/tmp/manifest.json" && \
+    # Extract artifact URLs using helper script
+    ARTIFACT_URLS=$(python3 /tmp/get_amazon_q_agentic_chat_artifacts.py /tmp/manifest.json $FLARE_SERVER_VERSION) && \
+    if [ $? -ne 0 ] || [ -z "$ARTIFACT_URLS" ]; then echo "Failed to extract Amazon Q artifact URLs" && exit 1; fi && \
+    eval $ARTIFACT_URLS && \
+    # Download and extract servers.zip
+    curl -L "$SERVERS_URL" -o "/tmp/servers.zip" && \
+    sudo unzip "/tmp/servers.zip" -d "/etc/amazon-q/artifacts/agentic-chat/servers" && \
+    # Download and extract clients.zip
+    curl -L "$CLIENTS_URL" -o "/tmp/clients.zip" && \
+    sudo unzip "/tmp/clients.zip" -d "/etc/amazon-q/artifacts/agentic-chat/clients" && \
+    # Clean up temporary files
+    rm -f /tmp/manifest.json /tmp/servers.zip /tmp/clients.zip && \
+    # Fix ownership for JupyterLab access
+    sudo chown -R $MAMBA_USER:$MAMBA_USER /etc/amazon-q/artifacts/ && \
     # Update npm version
     npm i -g npm && \
     # Enforce to use `conda-forge` as only channel, by removing `defaults`

--- a/test/test_amazon_q_artifacts.py
+++ b/test/test_amazon_q_artifacts.py
@@ -1,0 +1,190 @@
+from __future__ import absolute_import
+
+import json
+import os
+import pytest
+import tempfile
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+# Import the module under test
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'assets'))
+from get_amazon_q_agentic_chat_artifacts import extract_urls
+
+
+class TestAmazonQArtifacts:
+    """Test cases for Amazon Q Agentic Chat artifacts extraction."""
+
+    def test_extract_urls_success(self):
+        """Test successful URL extraction from manifest."""
+        manifest_data = {
+            "versions": [
+                {
+                    "serverVersion": "1.0.0",
+                    "targets": [
+                        {
+                            "platform": "linux",
+                            "arch": "x64",
+                            "contents": [
+                                {
+                                    "filename": "servers.zip",
+                                    "url": "https://example.com/servers.zip"
+                                },
+                                {
+                                    "filename": "clients.zip", 
+                                    "url": "https://example.com/clients.zip"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump(manifest_data, f)
+            manifest_file = f.name
+        
+        try:
+            servers_url, clients_url = extract_urls(manifest_file, "1.0.0")
+            assert servers_url == "https://example.com/servers.zip"
+            assert clients_url == "https://example.com/clients.zip"
+        finally:
+            os.unlink(manifest_file)
+
+    def test_extract_urls_version_not_found(self):
+        """Test error when version is not found."""
+        manifest_data = {
+            "versions": [
+                {
+                    "serverVersion": "1.0.0",
+                    "targets": []
+                }
+            ]
+        }
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump(manifest_data, f)
+            manifest_file = f.name
+        
+        try:
+            with pytest.raises(ValueError, match="Version 2.0.0 not found for linux x64"):
+                extract_urls(manifest_file, "2.0.0")
+        finally:
+            os.unlink(manifest_file)
+
+    def test_extract_urls_platform_not_found(self):
+        """Test error when platform/arch combination is not found."""
+        manifest_data = {
+            "versions": [
+                {
+                    "serverVersion": "1.0.0",
+                    "targets": [
+                        {
+                            "platform": "windows",
+                            "arch": "x64",
+                            "contents": []
+                        }
+                    ]
+                }
+            ]
+        }
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump(manifest_data, f)
+            manifest_file = f.name
+        
+        try:
+            with pytest.raises(ValueError, match="Version 1.0.0 not found for linux x64"):
+                extract_urls(manifest_file, "1.0.0")
+        finally:
+            os.unlink(manifest_file)
+
+    def test_extract_urls_missing_files(self):
+        """Test behavior when required files are missing."""
+        manifest_data = {
+            "versions": [
+                {
+                    "serverVersion": "1.0.0",
+                    "targets": [
+                        {
+                            "platform": "linux",
+                            "arch": "x64",
+                            "contents": [
+                                {
+                                    "filename": "other.zip",
+                                    "url": "https://example.com/other.zip"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump(manifest_data, f)
+            manifest_file = f.name
+        
+        try:
+            servers_url, clients_url = extract_urls(manifest_file, "1.0.0")
+            assert servers_url is None
+            assert clients_url is None
+        finally:
+            os.unlink(manifest_file)
+
+    def test_extract_urls_custom_platform(self):
+        """Test URL extraction with custom platform and arch."""
+        manifest_data = {
+            "versions": [
+                {
+                    "serverVersion": "1.0.0",
+                    "targets": [
+                        {
+                            "platform": "darwin",
+                            "arch": "arm64",
+                            "contents": [
+                                {
+                                    "filename": "servers.zip",
+                                    "url": "https://example.com/darwin-servers.zip"
+                                },
+                                {
+                                    "filename": "clients.zip",
+                                    "url": "https://example.com/darwin-clients.zip"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            json.dump(manifest_data, f)
+            manifest_file = f.name
+        
+        try:
+            servers_url, clients_url = extract_urls(manifest_file, "1.0.0", "darwin", "arm64")
+            assert servers_url == "https://example.com/darwin-servers.zip"
+            assert clients_url == "https://example.com/darwin-clients.zip"
+        finally:
+            os.unlink(manifest_file)
+
+    def test_extract_urls_invalid_json(self):
+        """Test error handling for invalid JSON."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            f.write("invalid json")
+            manifest_file = f.name
+        
+        try:
+            with pytest.raises(json.JSONDecodeError):
+                extract_urls(manifest_file, "1.0.0")
+        finally:
+            os.unlink(manifest_file)
+
+    def test_extract_urls_file_not_found(self):
+        """Test error handling for missing manifest file."""
+        with pytest.raises(FileNotFoundError):
+            extract_urls("nonexistent.json", "1.0.0")

--- a/test/test_main_amazon_q_integration.py
+++ b/test/test_main_amazon_q_integration.py
@@ -1,0 +1,168 @@
+from __future__ import absolute_import
+
+import os
+import pytest
+import tempfile
+from unittest.mock import patch, MagicMock
+
+pytestmark = pytest.mark.unit
+
+from main import _copy_static_files
+from utils import get_semver
+
+
+class TestMainAmazonQIntegration:
+    """Test cases for Amazon Q integration in main.py."""
+
+    @patch('shutil.copy2')
+    @patch('os.path.exists')
+    def test_copy_static_files_with_amazon_q_script(self, mock_exists, mock_copy):
+        """Test that Amazon Q artifacts script is copied when it exists."""
+        # Mock file existence checks
+        def exists_side_effect(path):
+            if path.endswith('aws-cli-public-key.asc'):
+                return True
+            elif path.endswith('get_amazon_q_agentic_chat_artifacts.py'):
+                return True
+            elif path.endswith('dirs'):
+                return True
+            return False
+        
+        mock_exists.side_effect = exists_side_effect
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base_version_dir = os.path.join(temp_dir, "base")
+            new_version_dir = os.path.join(temp_dir, "new")
+            os.makedirs(base_version_dir)
+            os.makedirs(new_version_dir)
+            
+            # Call the function
+            _copy_static_files(base_version_dir, new_version_dir, "2", "minor")
+            
+            # Verify that copy2 was called for Amazon Q script
+            copy_calls = [call[0][0] for call in mock_copy.call_args_list]
+            amazon_q_calls = [call for call in copy_calls if 'get_amazon_q_agentic_chat_artifacts.py' in call]
+            assert len(amazon_q_calls) == 1
+            assert amazon_q_calls[0] == "assets/get_amazon_q_agentic_chat_artifacts.py"
+
+    @patch('shutil.copy2')
+    @patch('os.path.exists')
+    def test_copy_static_files_without_amazon_q_script(self, mock_exists, mock_copy):
+        """Test that function works when Amazon Q artifacts script doesn't exist."""
+        # Mock file existence checks - Amazon Q script doesn't exist
+        def exists_side_effect(path):
+            if path.endswith('aws-cli-public-key.asc'):
+                return True
+            elif path.endswith('get_amazon_q_agentic_chat_artifacts.py'):
+                return False  # Script doesn't exist
+            elif path.endswith('dirs'):
+                return True
+            return False
+        
+        mock_exists.side_effect = exists_side_effect
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base_version_dir = os.path.join(temp_dir, "base")
+            new_version_dir = os.path.join(temp_dir, "new")
+            os.makedirs(base_version_dir)
+            os.makedirs(new_version_dir)
+            
+            # Call the function - should not raise exception
+            _copy_static_files(base_version_dir, new_version_dir, "2", "minor")
+            
+            # Verify that copy2 was not called for Amazon Q script
+            copy_calls = [call[0][0] for call in mock_copy.call_args_list]
+            amazon_q_calls = [call for call in copy_calls if 'get_amazon_q_agentic_chat_artifacts.py' in call]
+            assert len(amazon_q_calls) == 0
+
+    @patch('shutil.copy2')
+    @patch('shutil.copytree')
+    @patch('os.path.exists')
+    def test_copy_static_files_v1_and_above(self, mock_exists, mock_copytree, mock_copy):
+        """Test that dirs directory is copied for v1 and above."""
+        # Mock file existence checks
+        def exists_side_effect(path):
+            if path.endswith('aws-cli-public-key.asc'):
+                return True
+            elif path.endswith('get_amazon_q_agentic_chat_artifacts.py'):
+                return True
+            elif path.endswith('dirs'):
+                return True
+            return False
+        
+        mock_exists.side_effect = exists_side_effect
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base_version_dir = os.path.join(temp_dir, "base")
+            new_version_dir = os.path.join(temp_dir, "new")
+            os.makedirs(base_version_dir)
+            os.makedirs(new_version_dir)
+            
+            # Test with major version >= 1
+            _copy_static_files(base_version_dir, new_version_dir, "1", "minor")
+            
+            # Verify that copytree was called for dirs
+            assert mock_copytree.called
+            copytree_calls = [call[0] for call in mock_copytree.call_args_list]
+            dirs_calls = [call for call in copytree_calls if any('dirs' in str(arg) for arg in call)]
+            assert len(dirs_calls) > 0
+
+    @patch('shutil.copy2')
+    @patch('shutil.copytree')
+    @patch('os.path.exists')
+    def test_copy_static_files_v0(self, mock_exists, mock_copytree, mock_copy):
+        """Test that dirs directory is not copied for v0."""
+        # Mock file existence checks
+        def exists_side_effect(path):
+            if path.endswith('aws-cli-public-key.asc'):
+                return True
+            elif path.endswith('get_amazon_q_agentic_chat_artifacts.py'):
+                return True
+            elif path.endswith('dirs'):
+                return True
+            return False
+        
+        mock_exists.side_effect = exists_side_effect
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base_version_dir = os.path.join(temp_dir, "base")
+            new_version_dir = os.path.join(temp_dir, "new")
+            os.makedirs(base_version_dir)
+            os.makedirs(new_version_dir)
+            
+            # Test with major version 0
+            _copy_static_files(base_version_dir, new_version_dir, "0", "minor")
+            
+            # Verify that copytree was not called (dirs should not be copied for v0)
+            assert not mock_copytree.called
+
+    @patch('os.path.relpath')
+    @patch('shutil.copy2')
+    @patch('os.path.exists')
+    def test_copy_static_files_relative_paths(self, mock_exists, mock_copy, mock_relpath):
+        """Test that relative paths are used correctly."""
+        # Mock file existence checks
+        mock_exists.return_value = True
+        
+        # Mock relpath to return predictable values
+        def relpath_side_effect(path):
+            if 'aws-cli-public-key.asc' in path:
+                return 'base/aws-cli-public-key.asc'
+            elif 'dirs' in path:
+                return 'base/dirs'
+            return path
+        
+        mock_relpath.side_effect = relpath_side_effect
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base_version_dir = os.path.join(temp_dir, "base")
+            new_version_dir = os.path.join(temp_dir, "new")
+            os.makedirs(base_version_dir)
+            os.makedirs(new_version_dir)
+            
+            _copy_static_files(base_version_dir, new_version_dir, "2", "minor")
+            
+            # Verify relpath was called for the Amazon Q script
+            relpath_calls = [call[0][0] for call in mock_relpath.call_args_list]
+            amazon_q_calls = [call for call in relpath_calls if 'get_amazon_q_agentic_chat_artifacts.py' in call]
+            assert len(amazon_q_calls) == 1


### PR DESCRIPTION
Handle Amazon Q Agentic Chat artifacts and build improvements

## Description
Download Amazon Q Agentic Chat artifacts in SMD image to handle private subnet use case for 'SageMaker Unified Studio'. More details in [1].

## Type of Change
- [ X ] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ X ] Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]
Private subnet use case is broken for SMUS JL users with SMD 2.9. More details in [1]

## How Has This Been Tested?
 - [ X ] Existing unit tests passed
 - [ X ] New unit tests passed
 - [ X ] Followed instructions in CONTRIBUTING.md to test in 2.9.5 patch in local. Verified required artifacts are in right folder with right permissions and SMUS JL can use it. Check test results in [2].

## Checklist:
- [ X ] My code follows the style guidelines of this project
- [ X ] I have commented my code, particularly in hard-to-understand areas
- [ X ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):
Check test results in [2].

## Related Issues
See [1]

## References
[1] https://tiny.amazon.com/zmh6meka/tcorpamazP302
[2] https://tiny.amazon.com/2v58bfag/drivcorpamazfoldSMUSFail