### PR TITLE
[Sherpa] Add pre-packaged skills with persistence and subagent config for SMAI spaces

### DIFF
--- a/template/v4/Dockerfile
+++ b/template/v4/Dockerfile
@@ -91,16 +91,6 @@ RUN apt-get update && apt-get upgrade -y && \
     unzip /tmp/kirocli.zip -d /tmp && \
     Q_INSTALL_GLOBAL=1 KIRO_CLI_SKIP_SETUP=1 /tmp/kirocli/install.sh && \
     rm -rf /tmp/kirocli.zip /tmp/kirocli && \
-    : && \
-    # Clone skills from manifest config
-    mkdir -p /etc/sagemaker/skills && \
-    jq -c '.[]' /etc/sagemaker/skills/skills-manifest.json | while read -r entry; do \
-        repo=$(echo "$entry" | jq -r '.repo'); \
-        spath=$(echo "$entry" | jq -r '.path'); \
-        git clone --depth 1 "$repo" /tmp/skill-repo && \
-        cp -r "/tmp/skill-repo/$spath"/* /etc/sagemaker/skills/ && \
-        rm -rf /tmp/skill-repo; \
-    done && \
 # CodeEditor - create server, user data dirs
     mkdir -p /opt/amazon/sagemaker/sagemaker-code-editor-server-data /opt/amazon/sagemaker/sagemaker-ui-code-editor-server-data /opt/amazon/sagemaker/sagemaker-code-editor-user-data \
     && chown $MAMBA_USER:$MAMBA_USER /opt/amazon/sagemaker/sagemaker-code-editor-server-data /opt/amazon/sagemaker/sagemaker-ui-code-editor-server-data /opt/amazon/sagemaker/sagemaker-code-editor-user-data && \
@@ -112,6 +102,8 @@ RUN apt-get update && apt-get upgrade -y && \
 COPY dirs/ ${DIRECTORY_TREE_STAGE_DIR}/
 RUN rsync -a ${DIRECTORY_TREE_STAGE_DIR}/ / && \
     rm -rf ${DIRECTORY_TREE_STAGE_DIR} && \
+    # Clone skills from manifest config (must run after COPY dirs/ + rsync which provides skills-manifest.json)
+    bash /etc/sagemaker/skills/clone_skills.sh && \
 # CodeEditor - download the extensions
     mkdir -p /etc/code-editor/extensions /etc/code-editor/extensions-sagemaker-ui && \
     while IFS= read -r url || [ -n "$url" ]; do \

--- a/template/v4/Dockerfile
+++ b/template/v4/Dockerfile
@@ -91,6 +91,12 @@ RUN apt-get update && apt-get upgrade -y && \
     unzip /tmp/kirocli.zip -d /tmp && \
     Q_INSTALL_GLOBAL=1 KIRO_CLI_SKIP_SETUP=1 /tmp/kirocli/install.sh && \
     rm -rf /tmp/kirocli.zip /tmp/kirocli && \
+    : && \
+    # Clone SageMaker AI skills from GitHub
+    git clone --depth 1 https://github.com/awslabs/agent-plugins.git /tmp/agent-plugins && \
+    mkdir -p /etc/sagemaker/skills && \
+    cp -r /tmp/agent-plugins/plugins/sagemaker-ai/skills/* /etc/sagemaker/skills/ && \
+    rm -rf /tmp/agent-plugins && \
 # CodeEditor - create server, user data dirs
     mkdir -p /opt/amazon/sagemaker/sagemaker-code-editor-server-data /opt/amazon/sagemaker/sagemaker-ui-code-editor-server-data /opt/amazon/sagemaker/sagemaker-code-editor-user-data \
     && chown $MAMBA_USER:$MAMBA_USER /opt/amazon/sagemaker/sagemaker-code-editor-server-data /opt/amazon/sagemaker/sagemaker-ui-code-editor-server-data /opt/amazon/sagemaker/sagemaker-code-editor-user-data && \

--- a/template/v4/Dockerfile
+++ b/template/v4/Dockerfile
@@ -92,11 +92,15 @@ RUN apt-get update && apt-get upgrade -y && \
     Q_INSTALL_GLOBAL=1 KIRO_CLI_SKIP_SETUP=1 /tmp/kirocli/install.sh && \
     rm -rf /tmp/kirocli.zip /tmp/kirocli && \
     : && \
-    # Clone SageMaker AI skills from GitHub
-    git clone --depth 1 https://github.com/awslabs/agent-plugins.git /tmp/agent-plugins && \
+    # Clone skills from manifest config
     mkdir -p /etc/sagemaker/skills && \
-    cp -r /tmp/agent-plugins/plugins/sagemaker-ai/skills/* /etc/sagemaker/skills/ && \
-    rm -rf /tmp/agent-plugins && \
+    jq -c '.[]' /etc/sagemaker/skills/skills-manifest.json | while read -r entry; do \
+        repo=$(echo "$entry" | jq -r '.repo'); \
+        spath=$(echo "$entry" | jq -r '.path'); \
+        git clone --depth 1 "$repo" /tmp/skill-repo && \
+        cp -r "/tmp/skill-repo/$spath"/* /etc/sagemaker/skills/ && \
+        rm -rf /tmp/skill-repo; \
+    done && \
 # CodeEditor - create server, user data dirs
     mkdir -p /opt/amazon/sagemaker/sagemaker-code-editor-server-data /opt/amazon/sagemaker/sagemaker-ui-code-editor-server-data /opt/amazon/sagemaker/sagemaker-code-editor-user-data \
     && chown $MAMBA_USER:$MAMBA_USER /opt/amazon/sagemaker/sagemaker-code-editor-server-data /opt/amazon/sagemaker/sagemaker-ui-code-editor-server-data /opt/amazon/sagemaker/sagemaker-code-editor-user-data && \

--- a/template/v4/dirs/etc/sagemaker/mcp.json
+++ b/template/v4/dirs/etc/sagemaker/mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "jupyter_mcp_server": {
-      "type": "http",
-      "url": "http://localhost:8080/mcp"
-    }
-  }
-}

--- a/template/v4/dirs/etc/sagemaker/mcp.json
+++ b/template/v4/dirs/etc/sagemaker/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "jupyter_mcp_server": {
+      "type": "http",
+      "url": "http://localhost:8080/mcp"
+    }
+  }
+}

--- a/template/v4/dirs/etc/sagemaker/sagemaker-default-agent.json
+++ b/template/v4/dirs/etc/sagemaker/sagemaker-default-agent.json
@@ -1,12 +1,21 @@
 {
   "name": "sagemaker_default",
   "description": "SageMaker AI assistant with pre-installed skills for model customization, evaluation, deployment, and HyperPod operations.",
-  "tools": ["@builtin"],
-  "allowedTools": [
-    "mcp::jupyter-mcp::read_notebook",
-    "mcp::jupyter-mcp::read",
-    "mcp::jupyter-mcp::ls"
-  ],
+  "prompt": "You are a specialized AI assistant for Amazon SageMaker Studio. You can help with general purpose tasks, but you also have expertise in SageMaker workflows and skills.",
   "mcpServers": {},
-  "resources": []
+  "tools": ["*"],
+  "toolAliases": {},
+  "allowedTools": [
+    "@jupyter_mcp_server/read_notebook",
+    "@jupyter_mcp_server/read_notebook_cells",
+    "@jupyter_mcp_server/open_file",
+    "@jupyter_mcp_server/select_cell",
+    "@jupyter_mcp_server/get_active_notebook",
+    "@jupyter_mcp_server/get_active_cell_id",
+    "@jupyter_mcp_server/get_open_documents"
+  ],
+  "resources": ["skill://.kiro/skills/**/SKILL.md"],
+  "hooks": {},
+  "toolsSettings": {},
+  "includeMcpJson": true
 }

--- a/template/v4/dirs/etc/sagemaker/sagemaker-default-agent.json
+++ b/template/v4/dirs/etc/sagemaker/sagemaker-default-agent.json
@@ -1,0 +1,8 @@
+{
+  "name": "sagemaker_default",
+  "description": "SageMaker AI assistant with pre-installed skills for model customization, evaluation, deployment, and HyperPod operations.",
+  "tools": ["@builtin"],
+  "allowedTools": [],
+  "mcpServers": {},
+  "resources": []
+}

--- a/template/v4/dirs/etc/sagemaker/sagemaker-default-agent.json
+++ b/template/v4/dirs/etc/sagemaker/sagemaker-default-agent.json
@@ -2,7 +2,11 @@
   "name": "sagemaker_default",
   "description": "SageMaker AI assistant with pre-installed skills for model customization, evaluation, deployment, and HyperPod operations.",
   "tools": ["@builtin"],
-  "allowedTools": [],
+  "allowedTools": [
+    "mcp::jupyter-mcp::read_notebook",
+    "mcp::jupyter-mcp::read",
+    "mcp::jupyter-mcp::ls"
+  ],
   "mcpServers": {},
   "resources": []
 }

--- a/template/v4/dirs/etc/sagemaker/skills/clone_skills.sh
+++ b/template/v4/dirs/etc/sagemaker/skills/clone_skills.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Clones skills from repos listed in skills-manifest.json during Docker build.
+set -eu
+
+MANIFEST="/etc/sagemaker/skills/skills-manifest.json"
+DEST="/etc/sagemaker/skills"
+
+jq -c '.[]' "$MANIFEST" | while read -r entry; do
+    repo=$(echo "$entry" | jq -r '.repo')
+    spath=$(echo "$entry" | jq -r '.path')
+    git clone --depth 1 "$repo" /tmp/skill-repo
+    cp -r "/tmp/skill-repo/$spath"/* "$DEST"/
+    rm -rf /tmp/skill-repo
+done

--- a/template/v4/dirs/etc/sagemaker/skills/skills-manifest.json
+++ b/template/v4/dirs/etc/sagemaker/skills/skills-manifest.json
@@ -1,0 +1,6 @@
+[
+  {
+    "repo": "https://github.com/awslabs/agent-plugins.git",
+    "path": "plugins/sagemaker-ai/skills"
+  }
+]

--- a/template/v4/dirs/etc/sagemaker/skills/sync_skills.sh
+++ b/template/v4/dirs/etc/sagemaker/skills/sync_skills.sh
@@ -5,7 +5,9 @@ set -eu
 IMAGE_SKILLS_DIR="/etc/sagemaker/skills"
 EBS_SKILLS_DIR="$HOME/.agent/skills"
 LOCK_FILE="$EBS_SKILLS_DIR/.sagemaker-lock"
-KIRO_SKILLS_DIR="$HOME/.kiro/skills"
+
+# Agent targets to symlink skills into (add new agents here)
+AGENT_SKILLS_DIRS=("$HOME/.kiro/skills")
 
 compute_checksum() {
     (cd "$1" && find . -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum | awk '{print $1}')
@@ -21,7 +23,8 @@ set_locked_checksum() {
     mv "$LOCK_FILE.tmp" "$LOCK_FILE"
 }
 
-mkdir -p "$EBS_SKILLS_DIR" "$KIRO_SKILLS_DIR"
+mkdir -p "$EBS_SKILLS_DIR"
+for dir in "${AGENT_SKILLS_DIRS[@]}"; do mkdir -p "$dir"; done
 
 if [ ! -d "$IMAGE_SKILLS_DIR" ]; then
     echo "No bundled skills found at $IMAGE_SKILLS_DIR, skipping."
@@ -56,11 +59,14 @@ for skill_path in "$IMAGE_SKILLS_DIR"/*/; do
         fi
     fi
 
-    kiro_link="$KIRO_SKILLS_DIR/$skill_name"
-    if [ ! -e "$kiro_link" ]; then
-        ln -s "$ebs_skill" "$kiro_link"
-        echo "Created symlink $kiro_link -> $ebs_skill"
-    fi
+    # Create symlinks for all agent targets
+    for agent_dir in "${AGENT_SKILLS_DIRS[@]}"; do
+        link="$agent_dir/$skill_name"
+        if [ ! -e "$link" ]; then
+            ln -s "$ebs_skill" "$link"
+            echo "Created symlink $link -> $ebs_skill"
+        fi
+    done
 done
 
 echo "Skills sync complete."

--- a/template/v4/dirs/etc/sagemaker/skills/sync_skills.sh
+++ b/template/v4/dirs/etc/sagemaker/skills/sync_skills.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Syncs pre-packaged SageMaker skills from image to user's EBS.
+set -eu
+
+IMAGE_SKILLS_DIR="/etc/sagemaker/skills"
+EBS_SKILLS_DIR="$HOME/.agent/skills"
+LOCK_FILE="$EBS_SKILLS_DIR/.sagemaker-lock"
+KIRO_SKILLS_DIR="$HOME/.kiro/skills"
+
+compute_checksum() {
+    (cd "$1" && find . -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum | awk '{print $1}')
+}
+
+get_locked_checksum() {
+    [ -f "$LOCK_FILE" ] && jq -r --arg s "$1" '.skills[$s].checksum // empty' "$LOCK_FILE" 2>/dev/null
+}
+
+set_locked_checksum() {
+    [ -f "$LOCK_FILE" ] || echo '{"skills":{}}' > "$LOCK_FILE"
+    jq --arg s "$1" --arg c "$2" '.skills[$s].checksum = $c' "$LOCK_FILE" > "$LOCK_FILE.tmp"
+    mv "$LOCK_FILE.tmp" "$LOCK_FILE"
+}
+
+mkdir -p "$EBS_SKILLS_DIR" "$KIRO_SKILLS_DIR"
+
+if [ ! -d "$IMAGE_SKILLS_DIR" ]; then
+    echo "No bundled skills found at $IMAGE_SKILLS_DIR, skipping."
+    exit 0
+fi
+
+for skill_path in "$IMAGE_SKILLS_DIR"/*/; do
+    [ -d "$skill_path" ] || continue
+    skill_name=$(basename "$skill_path")
+    ebs_skill="$EBS_SKILLS_DIR/$skill_name"
+    image_checksum=$(compute_checksum "$skill_path")
+
+    if [ ! -d "$ebs_skill" ]; then
+        cp -r "$skill_path" "$ebs_skill"
+        set_locked_checksum "$skill_name" "$image_checksum"
+        echo "Installed skill '$skill_name'"
+    else
+        recorded_checksum=$(get_locked_checksum "$skill_name")
+        current_checksum=$(compute_checksum "$ebs_skill")
+
+        if [ "$current_checksum" = "$recorded_checksum" ]; then
+            if [ "$image_checksum" != "$recorded_checksum" ]; then
+                rm -rf "$ebs_skill"
+                cp -r "$skill_path" "$ebs_skill"
+                set_locked_checksum "$skill_name" "$image_checksum"
+                echo "Updated skill '$skill_name'"
+            else
+                echo "Skill '$skill_name' already current, skipping"
+            fi
+        else
+            echo "Skipping skill '$skill_name' — user modified"
+        fi
+    fi
+
+    kiro_link="$KIRO_SKILLS_DIR/$skill_name"
+    if [ ! -e "$kiro_link" ]; then
+        ln -s "$ebs_skill" "$kiro_link"
+        echo "Created symlink $kiro_link -> $ebs_skill"
+    fi
+done
+
+echo "Skills sync complete."

--- a/template/v4/dirs/etc/sagemaker/sync_agent.sh
+++ b/template/v4/dirs/etc/sagemaker/sync_agent.sh
@@ -4,19 +4,12 @@ set -eu
 
 AGENT_CONFIG_SRC="/etc/sagemaker/sagemaker-default-agent.json"
 AGENT_CONFIG_DST="$HOME/.kiro/agents/sagemaker-default-agent.json"
-MCP_CONFIG_SRC="/etc/sagemaker/mcp.json"
-MCP_CONFIG_DST="$HOME/.kiro/settings/mcp.json"
 KIRO_CLI_SETTINGS="$HOME/.kiro/settings/cli.json"
 
 # Install subagent config (always overwrite)
 mkdir -p "$HOME/.kiro/agents"
 cp "$AGENT_CONFIG_SRC" "$AGENT_CONFIG_DST"
 echo "Installed agent config to $AGENT_CONFIG_DST"
-
-# Install MCP config (always overwrite)
-mkdir -p "$HOME/.kiro/settings"
-cp "$MCP_CONFIG_SRC" "$MCP_CONFIG_DST"
-echo "Installed MCP config to $MCP_CONFIG_DST"
 
 # Set default agent only if user hasn't configured one
 mkdir -p "$HOME/.kiro/settings"

--- a/template/v4/dirs/etc/sagemaker/sync_agent.sh
+++ b/template/v4/dirs/etc/sagemaker/sync_agent.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Syncs agent config (subagent, default agent settings) for SMAI spaces.
+set -eu
+
+AGENT_CONFIG_SRC="/etc/sagemaker/sagemaker-default-agent.json"
+AGENT_CONFIG_DST="$HOME/.kiro/agents/sagemaker-default-agent.json"
+KIRO_CLI_SETTINGS="$HOME/.kiro/settings/cli.json"
+
+# Install subagent config (always overwrite)
+mkdir -p "$HOME/.kiro/agents"
+cp "$AGENT_CONFIG_SRC" "$AGENT_CONFIG_DST"
+echo "Installed agent config to $AGENT_CONFIG_DST"
+
+# Set default agent only if user hasn't configured one
+mkdir -p "$HOME/.kiro/settings"
+if [ ! -f "$KIRO_CLI_SETTINGS" ]; then
+    echo '{"chat.defaultAgent":"sagemaker_default"}' > "$KIRO_CLI_SETTINGS"
+    echo "Created default agent settings"
+elif ! jq -e '."chat.defaultAgent"' "$KIRO_CLI_SETTINGS" >/dev/null 2>&1; then
+    jq '. + {"chat.defaultAgent":"sagemaker_default"}' "$KIRO_CLI_SETTINGS" > "$KIRO_CLI_SETTINGS.tmp"
+    mv "$KIRO_CLI_SETTINGS.tmp" "$KIRO_CLI_SETTINGS"
+    echo "Added default agent to existing settings"
+fi

--- a/template/v4/dirs/etc/sagemaker/sync_agent.sh
+++ b/template/v4/dirs/etc/sagemaker/sync_agent.sh
@@ -4,12 +4,19 @@ set -eu
 
 AGENT_CONFIG_SRC="/etc/sagemaker/sagemaker-default-agent.json"
 AGENT_CONFIG_DST="$HOME/.kiro/agents/sagemaker-default-agent.json"
+MCP_CONFIG_SRC="/etc/sagemaker/mcp.json"
+MCP_CONFIG_DST="$HOME/.kiro/settings/mcp.json"
 KIRO_CLI_SETTINGS="$HOME/.kiro/settings/cli.json"
 
 # Install subagent config (always overwrite)
 mkdir -p "$HOME/.kiro/agents"
 cp "$AGENT_CONFIG_SRC" "$AGENT_CONFIG_DST"
 echo "Installed agent config to $AGENT_CONFIG_DST"
+
+# Install MCP config (always overwrite)
+mkdir -p "$HOME/.kiro/settings"
+cp "$MCP_CONFIG_SRC" "$MCP_CONFIG_DST"
+echo "Installed MCP config to $MCP_CONFIG_DST"
 
 # Set default agent only if user hasn't configured one
 mkdir -p "$HOME/.kiro/settings"

--- a/template/v4/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/dirs/usr/local/bin/start-jupyter-server
@@ -14,6 +14,28 @@ else
     micromamba remove -y sagemaker-studio-dataengineering-sessions sagemaker-studio-dataengineering-extensions
     # Disable SMUS-specific extensions
     jupyter labextension disable sagemaker-data-explorer:plugin
+    # Disable old Q chat extension
+    jupyter labextension disable @amzn/amazon_sagemaker_jupyter_ai_q_developer
+fi
+
+# Setup skills and subagent for SMAI spaces
+if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
+    # Sync pre-packaged skills to EBS
+    bash /etc/sagemaker/skills/sync_skills.sh || echo "Warning: skills sync failed, continuing..."
+
+    # Install subagent config (always overwrite)
+    mkdir -p "$HOME/.kiro/agents"
+    cp /etc/sagemaker/sagemaker-default-agent.json "$HOME/.kiro/agents/sagemaker-default-agent.json"
+
+    # Set default agent only if user hasn't configured one
+    KIRO_CLI_SETTINGS="$HOME/.kiro/settings/cli.json"
+    mkdir -p "$HOME/.kiro/settings"
+    if [ ! -f "$KIRO_CLI_SETTINGS" ]; then
+        echo '{"chat.defaultAgent":"sagemaker_default"}' > "$KIRO_CLI_SETTINGS"
+    elif ! jq -e '."chat.defaultAgent"' "$KIRO_CLI_SETTINGS" >/dev/null 2>&1; then
+        jq '. + {"chat.defaultAgent":"sagemaker_default"}' "$KIRO_CLI_SETTINGS" > "$KIRO_CLI_SETTINGS.tmp"
+        mv "$KIRO_CLI_SETTINGS.tmp" "$KIRO_CLI_SETTINGS"
+    fi
 fi
 
 # Enable S3AG plugin if TIP is enabled

--- a/template/v4/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/dirs/usr/local/bin/start-jupyter-server
@@ -21,21 +21,10 @@ fi
 # Setup skills and subagent for SMAI spaces
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
     # Sync pre-packaged skills to EBS
-    bash /etc/sagemaker/skills/sync_skills.sh || echo "Warning: skills sync failed, continuing..."
+    bash /etc/sagemaker/skills/sync_skills.sh 2>&1 || echo "Warning: skills sync failed, continuing..."
 
-    # Install subagent config (always overwrite)
-    mkdir -p "$HOME/.kiro/agents"
-    cp /etc/sagemaker/sagemaker-default-agent.json "$HOME/.kiro/agents/sagemaker-default-agent.json"
-
-    # Set default agent only if user hasn't configured one
-    KIRO_CLI_SETTINGS="$HOME/.kiro/settings/cli.json"
-    mkdir -p "$HOME/.kiro/settings"
-    if [ ! -f "$KIRO_CLI_SETTINGS" ]; then
-        echo '{"chat.defaultAgent":"sagemaker_default"}' > "$KIRO_CLI_SETTINGS"
-    elif ! jq -e '."chat.defaultAgent"' "$KIRO_CLI_SETTINGS" >/dev/null 2>&1; then
-        jq '. + {"chat.defaultAgent":"sagemaker_default"}' "$KIRO_CLI_SETTINGS" > "$KIRO_CLI_SETTINGS.tmp"
-        mv "$KIRO_CLI_SETTINGS.tmp" "$KIRO_CLI_SETTINGS"
-    fi
+    # Sync agent config (subagent + default agent settings)
+    bash /etc/sagemaker/sync_agent.sh 2>&1 || echo "Warning: agent config sync failed, continuing..."
 fi
 
 # Enable S3AG plugin if TIP is enabled

--- a/template/v4/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/dirs/usr/local/bin/start-jupyter-server
@@ -18,8 +18,8 @@ else
     jupyter labextension disable @amzn/amazon_sagemaker_jupyter_ai_q_developer
 fi
 
-# Setup skills and subagent for SMAI spaces
-if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
+# Setup skills and subagent for SMAI private spaces only
+if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" != "shared" ]; then
     # Sync pre-packaged skills to EBS
     bash /etc/sagemaker/skills/sync_skills.sh 2>&1 || echo "Warning: skills sync failed, continuing..."
 


### PR DESCRIPTION
## Description
Pre-package SageMaker AI skills from github (https://github.com/awslabs/agent-plugins/tree/main/plugins/sagemaker-ai/skills) into the SMD v4 image and sync them to user EBS on SMAI space startup with checksum-based persistence.

- Bundle skills from awslabs/agent-plugins into /etc/sagemaker/skills/ during Docker build
- Add sync_skills.sh for checksum-based skills persistence on EBS
- Add sagemaker_default subagent config
- Configure skills sync, subagent, and default agent on SMAI space startup
- Disable old Q chat extension for SMAI spaces

## Type of Change
- [ ] Image update - Bug fix
- [x] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ ] Yes (Critical bug fix or security update)
- [x] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]

## How Has This Been Tested?
[Describe the tests you ran]

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
MCP integration PR: https://github.com/aws/sagemaker-distribution/pull/1108/commits
(separate, not included here)

## Additional Notes
Need to add jupyter ai v3
