### PR TITLE
Disable JAI v3 chat extensions for SMUS and SMAI shared spaces

### DIFF
--- a/template/v4/dirs/etc/sagemaker-ui/jupyter/lab/settings/page_config.json
+++ b/template/v4/dirs/etc/sagemaker-ui/jupyter/lab/settings/page_config.json
@@ -8,6 +8,16 @@
       "@amzn/sagemaker-jupyterlab-extensions:spacemenu": true,
       "@amzn/amazon_sagemaker_sql_editor": true,
       "@sagemaker-studio:EmrCluster": true,
-      "@jupyter/collaboration-extension": true
+      "@jupyter/collaboration-extension": true,
+      "jupyterlab-chat-extension": true,
+      "@jupyter-ai/jupyternaut": true,
+      "@jupyter-ai/router": true,
+      "@jupyter-ai/persona-manager": true,
+      "@jupyter-ai/acp-client": true,
+      "@jupyter-ai/chat-commands": true,
+      "@jupyter-ai-contrib/server-documents": true,
+      "jupyterlab-commands-toolkit": true,
+      "jupyterlab-notebook-awareness": true,
+      "jupyterlab-eventlistener": true
     }
 }

--- a/template/v4/dirs/etc/sagemaker-ui/jupyter/server/jupyter_server_config.py
+++ b/template/v4/dirs/etc/sagemaker-ui/jupyter/server/jupyter_server_config.py
@@ -35,6 +35,20 @@ try:
 except:
     pass
 
+# Disable JAI v3 server extensions for SMUS
+c.ServerApp.jpserver_extensions = {
+    "jupyter_ai": False,
+    "jupyter_ai_acp_client": False,
+    "jupyter_ai_tools": False,
+    "jupyter_ai_persona_manager": False,
+    "jupyter_ai_router": False,
+    "jupyter_ai_jupyternaut": False,
+    "jupyter_ai_chat_commands": False,
+    "jupyter_server_documents": False,
+    "jupyter_server_mcp": False,
+    "jupyterlab_chat": False,
+}
+
 c.SchedulerApp.scheduler_class = SageMakerUnifiedStudioScheduler
 c.SchedulerApp.environment_manager_class = SagemakerEnvironmentManager
 c.SchedulerApp.job_files_manager_class = SageMakerJobFilesManager

--- a/template/v4/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/dirs/usr/local/bin/start-jupyter-server
@@ -46,6 +46,8 @@ fi
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ] && [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
   jupyter labextension enable @jupyter/collaboration-extension
   jupyter labextension enable @jupyter/docprovider-extension
+  # Disable chat icon in shared spaces
+  jupyter labextension disable jupyterlab-chat-extension
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   # SAGEMAKER_SPACE_TYPE_LOWERCASE flag is used to determine if the server should start

--- a/template/v4/dirs/usr/local/bin/start-sagemaker-ui-jupyter-server
+++ b/template/v4/dirs/usr/local/bin/start-sagemaker-ui-jupyter-server
@@ -11,9 +11,6 @@ else
     # Activate conda environment 'base' which is the default for Cosmos
     micromamba activate base
 
-    # Disable jupyter-ai in favor of sagemaker_gen_ai_jupyterlab_extension
-    jupyter labextension disable @jupyter-ai/core
-
     # Enable RTC to allow async Q file updates
     jupyter labextension enable @jupyter/docprovider-extension
 fi


### PR DESCRIPTION
## Description
- Disable JAI v3 lab extensions for SMUS in page_config.json
- Disable JAI v3 server extensions for SMUS in jupyter_server_config.py
- Disable jupyterlab-chat-extension in SMAI shared spaces
- Remove obsolete @jupyter-ai/core disable from SMUS startup

## Type of Change
- [ ] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ ] Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]

## How Has This Been Tested?
- Built a v4.1.0 image locally and uploaded it to studio space as a custom image, tested out sherpa related scenarios

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
[Link any related issues here]

## Additional Notes
[Any additional information that might be helpful for reviewers]
