### PR TITLE
Enable jupyter_server_documents and disable docprovider-extension for all spaces

### DIFF
--- a/build_artifacts/v4/v4.1/v4.1.0/dirs/etc/sagemaker-ui/jupyter/lab/settings/page_config.json
+++ b/build_artifacts/v4/v4.1/v4.1.0/dirs/etc/sagemaker-ui/jupyter/lab/settings/page_config.json
@@ -15,7 +15,6 @@
       "@jupyter-ai/persona-manager": true,
       "@jupyter-ai/acp-client": true,
       "@jupyter-ai/chat-commands": true,
-      "@jupyter-ai-contrib/server-documents": true,
       "jupyterlab-commands-toolkit": true,
       "jupyterlab-notebook-awareness": true,
       "jupyterlab-eventlistener": true

--- a/build_artifacts/v4/v4.1/v4.1.0/dirs/etc/sagemaker-ui/jupyter/server/jupyter_server_config.py
+++ b/build_artifacts/v4/v4.1/v4.1.0/dirs/etc/sagemaker-ui/jupyter/server/jupyter_server_config.py
@@ -44,7 +44,6 @@ c.ServerApp.jpserver_extensions = {
     "jupyter_ai_router": False,
     "jupyter_ai_jupyternaut": False,
     "jupyter_ai_chat_commands": False,
-    "jupyter_server_documents": False,
     "jupyter_server_mcp": False,
     "jupyterlab_chat": False,
 }

--- a/build_artifacts/v4/v4.1/v4.1.0/dirs/usr/local/bin/start-jupyter-server
+++ b/build_artifacts/v4/v4.1/v4.1.0/dirs/usr/local/bin/start-jupyter-server
@@ -45,7 +45,6 @@ fi
 # Start Jupyter server in rtc mode for shared spaces (skip in recovery mode)
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ] && [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
   jupyter labextension enable @jupyter/collaboration-extension
-  jupyter labextension enable @jupyter/docprovider-extension
   # Disable chat icon in shared spaces
   jupyter labextension disable jupyterlab-chat-extension
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker

--- a/build_artifacts/v4/v4.1/v4.1.0/dirs/usr/local/bin/start-sagemaker-ui-jupyter-server
+++ b/build_artifacts/v4/v4.1/v4.1.0/dirs/usr/local/bin/start-sagemaker-ui-jupyter-server
@@ -11,8 +11,6 @@ else
     # Activate conda environment 'base' which is the default for Cosmos
     micromamba activate base
 
-    # Enable RTC to allow async Q file updates
-    jupyter labextension enable @jupyter/docprovider-extension
 fi
 
 sudo cp -r /etc/sagemaker-ui/kernels/. /opt/conda/share/jupyter/kernels/

--- a/template/v4/dirs/etc/sagemaker-ui/jupyter/lab/settings/page_config.json
+++ b/template/v4/dirs/etc/sagemaker-ui/jupyter/lab/settings/page_config.json
@@ -15,7 +15,6 @@
       "@jupyter-ai/persona-manager": true,
       "@jupyter-ai/acp-client": true,
       "@jupyter-ai/chat-commands": true,
-      "@jupyter-ai-contrib/server-documents": true,
       "jupyterlab-commands-toolkit": true,
       "jupyterlab-notebook-awareness": true,
       "jupyterlab-eventlistener": true

--- a/template/v4/dirs/etc/sagemaker-ui/jupyter/server/jupyter_server_config.py
+++ b/template/v4/dirs/etc/sagemaker-ui/jupyter/server/jupyter_server_config.py
@@ -44,7 +44,6 @@ c.ServerApp.jpserver_extensions = {
     "jupyter_ai_router": False,
     "jupyter_ai_jupyternaut": False,
     "jupyter_ai_chat_commands": False,
-    "jupyter_server_documents": False,
     "jupyter_server_mcp": False,
     "jupyterlab_chat": False,
 }

--- a/template/v4/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/dirs/usr/local/bin/start-jupyter-server
@@ -45,7 +45,6 @@ fi
 # Start Jupyter server in rtc mode for shared spaces (skip in recovery mode)
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ] && [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
   jupyter labextension enable @jupyter/collaboration-extension
-  jupyter labextension enable @jupyter/docprovider-extension
   # Disable chat icon in shared spaces
   jupyter labextension disable jupyterlab-chat-extension
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker

--- a/template/v4/dirs/usr/local/bin/start-sagemaker-ui-jupyter-server
+++ b/template/v4/dirs/usr/local/bin/start-sagemaker-ui-jupyter-server
@@ -11,8 +11,6 @@ else
     # Activate conda environment 'base' which is the default for Cosmos
     micromamba activate base
 
-    # Enable RTC to allow async Q file updates
-    jupyter labextension enable @jupyter/docprovider-extension
 fi
 
 sudo cp -r /etc/sagemaker-ui/kernels/. /opt/conda/share/jupyter/kernels/


### PR DESCRIPTION
## Description
- Enable jupyter_server_documents for SMUS in jupyter_server_config.py
- Remove @jupyter-ai-contrib/server-documents from disabledExtensions for SMUS
- Remove docprovider-extension enable from start-sagemaker-ui-jupyter-server (SMUS)
- Remove docprovider-extension enable from start-jupyter-server (SMAI shared)

## Type of Change
- [ ] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ ] Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]

## How Has This Been Tested?
[Describe the tests you ran]

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
https://github.com/aws/sagemaker-distribution/pull/1164

## Additional Notes
Changes applied to both template/v4 and build_artifacts/v4/v4.1/v4.1.0
