### PR TITLE
Fix server disable

### DIFF
--- a/build_artifacts/v4/v4.1/v4.1.0/dirs/etc/sagemaker-ui/jupyter/server/jupyter_server_config.d/zzz_sagemaker_ui_overrides.json
+++ b/build_artifacts/v4/v4.1/v4.1.0/dirs/etc/sagemaker-ui/jupyter/server/jupyter_server_config.d/zzz_sagemaker_ui_overrides.json
@@ -1,0 +1,15 @@
+{
+    "ServerApp": {
+        "jpserver_extensions": {
+            "jupyter_ai": false,
+            "jupyter_ai_acp_client": false,
+            "jupyter_ai_tools": false,
+            "jupyter_ai_persona_manager": false,
+            "jupyter_ai_router": false,
+            "jupyter_ai_jupyternaut": false,
+            "jupyter_ai_chat_commands": false,
+            "jupyter_server_mcp": false,
+            "jupyterlab_chat": false
+        }
+    }
+}

--- a/build_artifacts/v4/v4.1/v4.1.0/dirs/etc/sagemaker-ui/jupyter/server/jupyter_server_config.py
+++ b/build_artifacts/v4/v4.1/v4.1.0/dirs/etc/sagemaker-ui/jupyter/server/jupyter_server_config.py
@@ -35,20 +35,6 @@ try:
 except:
     pass
 
-# Disable JAI v3 server extensions for SMUS
-c.ServerApp.jpserver_extensions = {
-    "jupyter_ai": False,
-    "jupyter_ai_acp_client": False,
-    "jupyter_ai_tools": False,
-    "jupyter_ai_persona_manager": False,
-    "jupyter_ai_router": False,
-    "jupyter_ai_jupyternaut": False,
-    "jupyter_ai_chat_commands": False,
-    "jupyter_server_documents": False,
-    "jupyter_server_mcp": False,
-    "jupyterlab_chat": False,
-}
-
 c.SchedulerApp.scheduler_class = SageMakerUnifiedStudioScheduler
 c.SchedulerApp.environment_manager_class = SagemakerEnvironmentManager
 c.SchedulerApp.job_files_manager_class = SageMakerJobFilesManager

--- a/build_artifacts/v4/v4.1/v4.1.0/dirs/usr/local/bin/start-sagemaker-ui-jupyter-server
+++ b/build_artifacts/v4/v4.1/v4.1.0/dirs/usr/local/bin/start-sagemaker-ui-jupyter-server
@@ -17,6 +17,7 @@ fi
 
 sudo cp -r /etc/sagemaker-ui/kernels/. /opt/conda/share/jupyter/kernels/
 sudo cp /etc/sagemaker-ui/jupyter/server/jupyter_server_config.py /opt/conda/etc/jupyter/
+sudo cp /etc/sagemaker-ui/jupyter/server/jupyter_server_config.d/zzz_sagemaker_ui_overrides.json /opt/conda/etc/jupyter/jupyter_server_config.d/
 
 mkdir -p /opt/conda/share/jupyter/lab/settings
 cp -r /etc/sagemaker-ui/jupyter/lab/settings/. /opt/conda/share/jupyter/lab/settings

--- a/template/v4/dirs/etc/sagemaker-ui/jupyter/server/jupyter_server_config.d/zzz_sagemaker_ui_overrides.json
+++ b/template/v4/dirs/etc/sagemaker-ui/jupyter/server/jupyter_server_config.d/zzz_sagemaker_ui_overrides.json
@@ -1,0 +1,15 @@
+{
+    "ServerApp": {
+        "jpserver_extensions": {
+            "jupyter_ai": false,
+            "jupyter_ai_acp_client": false,
+            "jupyter_ai_tools": false,
+            "jupyter_ai_persona_manager": false,
+            "jupyter_ai_router": false,
+            "jupyter_ai_jupyternaut": false,
+            "jupyter_ai_chat_commands": false,
+            "jupyter_server_mcp": false,
+            "jupyterlab_chat": false
+        }
+    }
+}

--- a/template/v4/dirs/etc/sagemaker-ui/jupyter/server/jupyter_server_config.py
+++ b/template/v4/dirs/etc/sagemaker-ui/jupyter/server/jupyter_server_config.py
@@ -35,20 +35,6 @@ try:
 except:
     pass
 
-# Disable JAI v3 server extensions for SMUS
-c.ServerApp.jpserver_extensions = {
-    "jupyter_ai": False,
-    "jupyter_ai_acp_client": False,
-    "jupyter_ai_tools": False,
-    "jupyter_ai_persona_manager": False,
-    "jupyter_ai_router": False,
-    "jupyter_ai_jupyternaut": False,
-    "jupyter_ai_chat_commands": False,
-    "jupyter_server_documents": False,
-    "jupyter_server_mcp": False,
-    "jupyterlab_chat": False,
-}
-
 c.SchedulerApp.scheduler_class = SageMakerUnifiedStudioScheduler
 c.SchedulerApp.environment_manager_class = SagemakerEnvironmentManager
 c.SchedulerApp.job_files_manager_class = SageMakerJobFilesManager

--- a/template/v4/dirs/usr/local/bin/start-sagemaker-ui-jupyter-server
+++ b/template/v4/dirs/usr/local/bin/start-sagemaker-ui-jupyter-server
@@ -17,6 +17,7 @@ fi
 
 sudo cp -r /etc/sagemaker-ui/kernels/. /opt/conda/share/jupyter/kernels/
 sudo cp /etc/sagemaker-ui/jupyter/server/jupyter_server_config.py /opt/conda/etc/jupyter/
+sudo cp /etc/sagemaker-ui/jupyter/server/jupyter_server_config.d/zzz_sagemaker_ui_overrides.json /opt/conda/etc/jupyter/jupyter_server_config.d/
 
 mkdir -p /opt/conda/share/jupyter/lab/settings
 cp -r /etc/sagemaker-ui/jupyter/lab/settings/. /opt/conda/share/jupyter/lab/settings


### PR DESCRIPTION
## Description
Fix JAI v3 server extensions not being disabled for SMUS. The `jpserver_extensions` dict in `jupyter_server_config.py` was being overridden by per-extension JSON files in `jupyter_server_config.d/` that load with higher priority and set extensions back to `true`.

The fix adds a `zzz_sagemaker_ui_overrides.json` file in the `.d/` directory that sorts last alphabetically, ensuring its `false` values take final precedence. The now-redundant `jpserver_extensions` block is removed from `jupyter_server_config.py` to avoid confusion.

## Type of Change
- [x] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [x] Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
The server extension disabling from PR #1156 is not working. Extensions like `jupyter_ai_acp_client`, `jupyter_ai_tools`, `jupyter_ai_persona_manager`, `jupyter_ai_router`, `jupyter_ai_chat_commands`, and `jupyterlab_chat` all show as enabled in running Spaces despite the config setting them to `False`. This is because the `.d/*.json` config files installed by each package override the `.py` config at load time.

## How Has This Been Tested?
- Verified in a live Space that `jupyter server extension list` shows JAI v3 extensions as enabled despite the `.py` config
- Confirmed the root cause by inspecting `/opt/conda/etc/jupyter/jupyter_server_config.d/` and finding per-extension JSON files that set `true`
- Validated via Jupyter/traitlets documentation that `.d/` JSON configs merge with higher priority than `.py` configs, and alphabetical ordering determines precedence within `.d/`

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
#1156

## Additional Notes
Changes applied to both `template/v4` and `build_artifacts/v4/v4.1/v4.1.0`.

Files changed:
- **New**: `dirs/etc/sagemaker-ui/jupyter/server/jupyter_server_config.d/zzz_sagemaker_ui_overrides.json` — disables 9 JAI v3 extensions via the `.d/` mechanism
- **Modified**: `dirs/usr/local/bin/start-sagemaker-ui-jupyter-server` — copies the override JSON into `/opt/conda/etc/jupyter/jupyter_server_config.d/`
- **Modified**: `dirs/etc/sagemaker-ui/jupyter/server/jupyter_server_config.py` — removed the redundant `jpserver_extensions` block (single source of truth is now the `.d/` override)
