### PR TITLE
Add aws-smus-cicd-cli to v4.2.0

### DIFF
--- a/build_artifacts/v4/v4.2/v4.2.0/cpu.env.in
+++ b/build_artifacts/v4/v4.2/v4.2.0/cpu.env.in
@@ -69,3 +69,4 @@ conda-forge::sagemaker-studio-dataengineering-sessions[version='>=1.3.19,<2.0.0'
 conda-forge::sagemaker-studio-dataengineering-extensions[version='>=1.3.9,<2.0.0']
 conda-forge::amzn-sagemaker-aiops-jupyterlab-extension[version='>=1.0.6,<2.0.0']
 conda-forge::aws-s3-access-grants-boto3-plugin[version='>=1.3.0,<2.0.0']
+conda-forge::aws-smus-cicd-cli[version='>=1.0.5,<2.0.0']

--- a/build_artifacts/v4/v4.2/v4.2.0/gpu.env.in
+++ b/build_artifacts/v4/v4.2/v4.2.0/gpu.env.in
@@ -69,3 +69,4 @@ conda-forge::sagemaker-studio-dataengineering-sessions[version='>=1.3.19,<2.0.0'
 conda-forge::sagemaker-studio-dataengineering-extensions[version='>=1.3.9,<2.0.0']
 conda-forge::amzn-sagemaker-aiops-jupyterlab-extension[version='>=1.0.6,<2.0.0']
 conda-forge::aws-s3-access-grants-boto3-plugin[version='>=1.3.0,<2.0.0']
+conda-forge::aws-smus-cicd-cli[version='>=1.0.5,<2.0.0']


### PR DESCRIPTION
Adds aws-smus-cicd-cli (>=1.0.5) as a dependency to make the SageMaker Unified Studio CI/CD CLI available in SMD v4.2.0.

https://github.com/aws/CICD-for-SageMakerUnifiedStudio