### PR TITLE
ci: declare contents: read on remove-nightly-build workflow

### DIFF
--- a/.github/workflows/remove-nightly-build.yml
+++ b/.github/workflows/remove-nightly-build.yml
@@ -14,6 +14,10 @@ concurrency:
 defaults:
     run:
         shell: bash -l {0}
+
+permissions:
+    contents: read   # the schedule-update step uses an external GH_TOKEN secret, not the default token
+
 jobs:
     update-nightly-schedule:
         name: Update nightly build schedule


### PR DESCRIPTION
The `remove-nightly-build.yml` workflow is one of the few in this repo without a `permissions:` declaration. It runs on `workflow_dispatch` to remove a version from `nightly_build_schedule.json`. The push-back step uses an external `secrets.GH_TOKEN`, not the default `GITHUB_TOKEN`, so the default token only needs `contents: read` for the checkout step.