### PR TITLE
Restore 777 permission within /home path in 4.x version

### DIFF
--- a/template/v4/Dockerfile
+++ b/template/v4/Dockerfile
@@ -266,7 +266,9 @@ RUN mkdir -p $SAGEMAKER_LOGGING_DIR && \
     && rm -rf /opt/conda/etc/conda/test-files/ \
     && find /opt/conda -name "yarn.lock" -type f -delete \
     && find /opt/conda/include/ -name "requirements.txt" -delete \
-    && rm -rf /tmp/*.in
+    && rm -rf /tmp/*.in \
+    # Restore /home to world-writable (systemd's tmpfiles.d on Ubuntu 24.04 sets it to 755)
+    && chmod 777 /home
 
 # Explicitly disable BuildKit for SM Studio Docker functionality
 ENV DOCKER_BUILDKIT=0


### PR DESCRIPTION
## Description
Restore 777 permission within /home path in 4.x version

## Type of Change
- [x] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ ] Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]

## How Has This Been Tested?
Rebuild 4.1.1 version at local with the change, the new image has `777` version under `/home` path as SMD 3.x versions

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
[Link any related issues here]

## Additional Notes
[Any additional information that might be helpful for reviewers]
