### PR TITLE
Add ~/.claude/skills to sync_skills.sh agent targets

### DIFF
--- a/template/v4/dirs/etc/sagemaker/skills/sync_skills.sh
+++ b/template/v4/dirs/etc/sagemaker/skills/sync_skills.sh
@@ -7,7 +7,7 @@ EBS_SKILLS_DIR="$HOME/.agent/skills"
 LOCK_FILE="$EBS_SKILLS_DIR/.sagemaker-lock"
 
 # Agent targets to symlink skills into (add new agents here)
-AGENT_SKILLS_DIRS=("$HOME/.kiro/skills")
+AGENT_SKILLS_DIRS=("$HOME/.kiro/skills" "$HOME/.claude/skills")
 
 compute_checksum() {
     (cd "$1" && find . -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum | awk '{print $1}')


### PR DESCRIPTION
## Description
Add `$HOME/.claude/skills` to the `AGENT_SKILLS_DIRS` array in `sync_skills.sh` so that skills are also symlinked into Claude's skills directory at startup.

## Type of Change
- [ ] Image update - Bug fix
- [x] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ ] Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]

## How Has This Been Tested?
Tested using custom image in SMAI space

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
[Link any related issues here]

## Additional Notes
[Any additional information that might be helpful for reviewers]
