### PR TITLE
Keep jupyter_server_mcp enabled by default, remove runtime enable/disable

### DIFF
--- a/template/v4/Dockerfile
+++ b/template/v4/Dockerfile
@@ -224,8 +224,6 @@ RUN if [[ -z $ARG_BASED_ENV_IN_FILENAME ]] ; \
     sed -i 's="PySpark"="SparkMagic PySpark"=g'  /opt/conda/share/jupyter/kernels/pysparkkernel/kernel.json && \
     # Configure RTC - disable jupyter_collaboration by default
     jupyter labextension disable @jupyter/collaboration-extension && \
-    # Disable MCP server extension by default - enabled at startup for SMAI spaces
-    jupyter server extension disable jupyter_server_mcp && \
     # Disable docprovider-extension for v3 and above images
     jupyter labextension disable @jupyter/docprovider-extension
 

--- a/template/v4/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/dirs/usr/local/bin/start-jupyter-server
@@ -27,10 +27,8 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
     bash /etc/sagemaker/sync_agent.sh 2>&1 || echo "Warning: agent config sync failed, continuing..."
 fi
 
-# Setup MCP for SMAI spaces only (disabled by default in Dockerfile)
+# Setup for SMAI spaces
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
-    jupyter server extension enable jupyter_server_mcp 2>/dev/null || true
-
     # Copy JupyterLab settings (overrides)
     mkdir -p /opt/conda/share/jupyter/lab/settings
     cp -r /etc/sagemaker/jupyter/lab/settings/. /opt/conda/share/jupyter/lab/settings/


### PR DESCRIPTION
## Description
Keep jupyter_server_mcp enabled by default (from install). Remove the disable in Dockerfile and the runtime enable in start-jupyter-server. SMUS already disables it via zzz_sagemaker_ui_overrides.json. Saves ~5.7s of container startup time.

## Type of Change
- [x] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ ] Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]

## How Has This Been Tested?
Built custom image from v4.1.1 build artifacts with this change applied. Tested in a SMAI Space:
- Verified MCP is enabled for SMAI: jupyter server extension list 2>&1 | grep mcp → jupyter_server_mcp enabled
- Verified Kiro can use Jupyter MCP Server tools (create_notebook, edit_cell) successfully

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
[Link any related issues here]

## Additional Notes
SMUS disables MCP via the static config file /etc/sagemakerui/jupyter/server/jupyter_server_config.d/zzz_sagemaker_ui_overrides.json, so there's no need to disable at build time and re-enable at runtime.
