### PR TITLE
Set Kiro as default AI persona for SMAI (Sherpa)

### DIFF
--- a/template/v4/dirs/etc/jupyter/jupyter_server_config.py
+++ b/template/v4/dirs/etc/jupyter/jupyter_server_config.py
@@ -26,3 +26,6 @@ try:
     c.LanguageServerManager.extra_node_roots = [f"{module_location}/sql-language-server"]
 except:
     pass
+
+# Set Kiro as the default AI persona
+c.PersonaManager.default_persona_id = "jupyter-ai-personas::jupyter_ai_acp_client::KiroAcpPersona"


### PR DESCRIPTION
## Description
Set Kiro as the default AI persona via `c.PersonaManager.default_persona_id` in `/etc/jupyter/jupyter_server_config.py`. This ensures Kiro responds to messages without @-mentioning in multi-agent setups

## Type of Change
- [ ] Image update - Bug fix
- [x] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ ] Yes (Critical bug fix or security update)
- [x] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]

## How Has This Been Tested?
- Built custom image, deployed to SMAI space
- Installed Claude as second agent
- Server logs confirm: Initialized 2 AI personas and Default persona set to 'Kiro'

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
[Link any related issues here]

## Additional Notes
[Any additional information that might be helpful for reviewers]
