### PR TITLE
Add read_cell and get_cell_id_from_index to allowedTools in kiro

### DIFF
--- a/template/v4/dirs/etc/sagemaker/sagemaker-default-agent.json
+++ b/template/v4/dirs/etc/sagemaker/sagemaker-default-agent.json
@@ -8,6 +8,8 @@
   "allowedTools": [
     "@jupyter_mcp_server/read_notebook",
     "@jupyter_mcp_server/read_notebook_cells",
+    "@jupyter_mcp_server/read_cell",
+    "@jupyter_mcp_server/get_cell_id_from_index",
     "@jupyter_mcp_server/open_file",
     "@jupyter_mcp_server/select_cell",
     "@jupyter_mcp_server/get_active_notebook",


### PR DESCRIPTION
## Description
Add \`@jupyter_mcp_server/read_cell\` and \`@jupyter_mcp_server/get_cell_id_from_index\` to the default agent allowedTools list in the v4 template.

## Type of Change
- [ ] Image update - Bug fix
- [x] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ ] Yes (Critical bug fix or security update)
- [x] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]

## How Has This Been Tested?
[Describe the tests you ran]

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
[Link any related issues here]

## Additional Notes
[Any additional information that might be helpful for reviewers]
