### PR TITLE
Keep MCP enabled by default, remove runtime enable/disable for v4.2.0

### DIFF
--- a/build_artifacts/v4/v4.2/v4.2.0/Dockerfile
+++ b/build_artifacts/v4/v4.2/v4.2.0/Dockerfile
@@ -224,8 +224,6 @@ RUN if [[ -z $ARG_BASED_ENV_IN_FILENAME ]] ; \
     sed -i 's="PySpark"="SparkMagic PySpark"=g'  /opt/conda/share/jupyter/kernels/pysparkkernel/kernel.json && \
     # Configure RTC - disable jupyter_collaboration by default
     jupyter labextension disable @jupyter/collaboration-extension && \
-    # Disable MCP server extension by default - enabled at startup for SMAI spaces
-    jupyter server extension disable jupyter_server_mcp && \
     # Disable docprovider-extension for v3 and above images
     jupyter labextension disable @jupyter/docprovider-extension
 

--- a/build_artifacts/v4/v4.2/v4.2.0/dirs/usr/local/bin/start-jupyter-server
+++ b/build_artifacts/v4/v4.2/v4.2.0/dirs/usr/local/bin/start-jupyter-server
@@ -25,10 +25,8 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
     bash /etc/sagemaker/sync_agent.sh 2>&1 || echo "Warning: agent config sync failed, continuing..."
 fi
 
-# Setup MCP for SMAI spaces only (disabled by default in Dockerfile)
+# Setup MCP for SMAI spaces only
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
-    jupyter server extension enable jupyter_server_mcp 2>/dev/null || true
-
     # Copy JupyterLab settings (overrides)
     mkdir -p /opt/conda/share/jupyter/lab/settings
     cp -r /etc/sagemaker/jupyter/lab/settings/. /opt/conda/share/jupyter/lab/settings/


### PR DESCRIPTION
## Description
Keep jupyter_server_mcp enabled by default (from install). Remove the disable in Dockerfile and the runtime enable in start-jupyter-server.

SMUS already disables MCP via zzz_sagemaker_ui_overrides.json, so there's no need to disable at build time and re-enable at runtime. Saves ~5.7s of container startup time.
## Type of Change
- [ ] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ ] Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]

## How Has This Been Tested?
The template fix is already merged on main (https://github.com/aws/sagemaker-distribution/pull/1202)
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
https://github.com/aws/sagemaker-distribution/pull/1202

## Additional Notes
[Any additional information that might be helpful for reviewers]
