### PR TITLE
docs: add SMD 4.2.x to supported image versions

### DIFF
--- a/support_policy.md
+++ b/support_policy.md
@@ -29,6 +29,7 @@ The tables below lists the supported SageMaker Distribution image versions and t
 
 | Image Version | ECR Image URI | Planned End of Support Date |
 | :---:         | :---:         | :---:                       |
+| 4.2.x         | public.ecr.aws/sagemaker/sagemaker-distribution:4.2-cpu  |  Dec 2nd, 2026  |
 | 4.1.x         | public.ecr.aws/sagemaker/sagemaker-distribution:4.1-cpu  |  Oct 29th, 2026  |
 | 4.0.x         | public.ecr.aws/sagemaker/sagemaker-distribution:4.0-cpu  |  Oct 7th, 2026  |
 | 3.9.x         | public.ecr.aws/sagemaker/sagemaker-distribution:3.9-cpu  |  Sep 29th, 2026  |
@@ -42,6 +43,7 @@ The tables below lists the supported SageMaker Distribution image versions and t
 
 | Image Version | ECR Image URI | Planned End of Support Date |
 | :---:         | :---:         | :---:                       |
+| 4.2.x         | public.ecr.aws/sagemaker/sagemaker-distribution:4.2-gpu  |  Dec 2nd, 2026  |
 | 4.1.x         | public.ecr.aws/sagemaker/sagemaker-distribution:4.1-gpu  |  Oct 29th, 2026  |
 | 4.0.x         | public.ecr.aws/sagemaker/sagemaker-distribution:4.0-gpu  |  Oct 7th, 2026  |
 | 3.9.x         | public.ecr.aws/sagemaker/sagemaker-distribution:3.9-gpu  |  Sep 29th, 2026  |


### PR DESCRIPTION
Add SMD `4.2.x` (CPU + GPU) to the Supported Image Versions tables following the 4.2.0 public release ([#1171](https://github.com/aws/sagemaker-distribution/pull/1171), merged 2026-06-02). Planned End of Support **Dec 2nd, 2026** (release + 6 months, consistent with 4.1.x: merged 2026-04-29 → Oct 29th, 2026).