### PR TITLE
feat: Add Kiro CLI MCP server configuration on space startup

### DIFF
--- a/build_artifacts/v4/v4.0/v4.0.6/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/build_artifacts/v4/v4.0/v4.0.6/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -295,52 +295,58 @@ fi
 
 # Setup SageMaker MCP configuration
 echo "Setting up SageMaker MCP configuration..."
-mkdir -p $HOME/.aws/amazonq/
-target_file="$HOME/.aws/amazonq/mcp.json"
 source_file="/etc/sagemaker-ui/sagemaker-mcp/mcp.json"
 
+# Write MCP config to both qcli and Kiro CLI paths
+mkdir -p "$HOME/.aws/amazonq/" "$HOME/.kiro/settings/"
+mcp_target_files=(
+    "$HOME/.aws/amazonq/mcp.json"
+    "$HOME/.kiro/settings/mcp.json"
+)
+
 if [ -f "$source_file" ]; then
-    # Extract all servers from source configuration
-    if [ -f "$target_file" ]; then
-        # Target file exists - merge configurations
-        echo "Existing MCP configuration found, merging configurations..."
+    for mcp_target_file in "${mcp_target_files[@]}"; do
+        if [ -f "$mcp_target_file" ]; then
+            # Target file exists - merge configurations
+            echo "Existing MCP configuration found at $mcp_target_file, merging configurations..."
 
-        # Check if it's valid JSON first
-        if jq empty "$target_file" 2>/dev/null; then
-            # Initialize mcpServers object if it doesn't exist
-            if ! jq -e '.mcpServers' "$target_file" >/dev/null 2>&1; then
-                echo "Creating mcpServers object in existing configuration"
-                jq '. + {"mcpServers":{}}' "$target_file" > "$target_file.tmp"
-                mv "$target_file.tmp" "$target_file"
-            fi
-
-            servers=$(jq '.mcpServers | keys[]' "$source_file" | tr -d '"')
-
-            # Add each server from source to target if it doesn't exist
-            for server in $servers; do
-                if ! jq -e ".mcpServers.\"$server\"" "$target_file" >/dev/null 2>&1; then
-                    server_config=$(jq ".mcpServers.\"$server\"" "$source_file")
-                    jq --arg name "$server" --argjson config "$server_config" \
-                        '.mcpServers[$name] = $config' "$target_file" > "$target_file.tmp"
-                    mv "$target_file.tmp" "$target_file"
-                    echo "Added server '$server' to existing configuration"
-                else
-                    echo "Server '$server' already exists in configuration"
+            # Check if it's valid JSON first
+            if jq empty "$mcp_target_file" 2>/dev/null; then
+                # Initialize mcpServers object if it doesn't exist
+                if ! jq -e '.mcpServers' "$mcp_target_file" >/dev/null 2>&1; then
+                    echo "Creating mcpServers object in existing configuration"
+                    jq '. + {"mcpServers":{}}' "$mcp_target_file" > "$mcp_target_file.tmp"
+                    mv "$mcp_target_file.tmp" "$mcp_target_file"
                 fi
-            done
+
+                servers=$(jq '.mcpServers | keys[]' "$source_file" | tr -d '"')
+
+                # Add each server from source to target if it doesn't exist
+                for server in $servers; do
+                    if ! jq -e ".mcpServers.\"$server\"" "$mcp_target_file" >/dev/null 2>&1; then
+                        server_config=$(jq ".mcpServers.\"$server\"" "$source_file")
+                        jq --arg name "$server" --argjson config "$server_config" \
+                            '.mcpServers[$name] = $config' "$mcp_target_file" > "$mcp_target_file.tmp"
+                        mv "$mcp_target_file.tmp" "$mcp_target_file"
+                        echo "Added server '$server' to $mcp_target_file"
+                    else
+                        echo "Server '$server' already exists in $mcp_target_file"
+                    fi
+                done
+            else
+                echo "Warning: $mcp_target_file is not valid JSON, replacing with default configuration"
+                cp "$source_file" "$mcp_target_file"
+            fi
         else
-            echo "Warning: Existing MCP configuration is not valid JSON, replacing with default configuration"
-            cp "$source_file" "$target_file"
+            # File doesn't exist, copy our configuration
+            cp "$source_file" "$mcp_target_file"
+            echo "Created new MCP configuration at $mcp_target_file"
         fi
-    else
-        # File doesn't exist, copy our configuration
-        cp "$source_file" "$target_file"
-        echo "Created new MCP configuration with default servers"
-    fi
-    # Replace AWS_REGION_NAME placeholder with actual region name
-    echo "Updating MCP configuration with AWS Region $REGION_NAME..."
-    sed -i "s/AWS_REGION_NAME/$REGION_NAME/g" "$target_file"
-    echo "Successfully added AWS Region $REGION_NAME to $target_file"
+        # Replace AWS_REGION_NAME placeholder with actual region name
+        echo "Updating MCP configuration with AWS Region $REGION_NAME..."
+        sed -i "s/AWS_REGION_NAME/$REGION_NAME/g" "$mcp_target_file"
+        echo "Successfully added AWS Region $REGION_NAME to $mcp_target_file"
+    done
     echo "Successfully configured MCP for SageMaker"
 else
     echo "Warning: MCP configuration file not found at $source_file"
@@ -348,6 +354,7 @@ fi
 
 # Migrating MCP configuration to new config file
 echo "Migrating MCP configuration to Amazon Q agents..."
+target_file="$HOME/.aws/amazonq/mcp.json"
 agents_target_file="$HOME/.aws/amazonq/agents/default.json"
 agents_source_file="/etc/sagemaker-ui/sagemaker-mcp/default.json"
 


### PR DESCRIPTION
## Description
Write MCP config to `~/.kiro/settings/mcp.json` in addition to the existing qcli path (`~/.aws/amazonq/mcp.json`) during post-startup. Uses the same additive merge logic — only adds servers that don't already exist, preserving user custom MCP configurations. This enables Kiro CLI to auto-load `smus-local-mcp` and `smus-spark-upgrade` MCP servers on both JupyterLab and Code Editor SMUS spaces.

## Type of Change
- [x] Image update - Bug fix
- [] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [] Yes (Critical bug fix or security update)
- [x] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
Kiro CLI is installed in v4.0+ but MCP servers are not discoverable because the post-startup only writes to the qcli config path. This is a patch to the release-4.0.6 branch to enable MCP functionality for Kiro CLI on existing v4.0.x images.

## How Has This Been Tested?
- Same change tested on v4.2.1 (built and pushed to ECR: `913826031242.dkr.ecr.us-east-2.amazonaws.com/sagemaker-distribution-test:4.2.1-cpu`)
- Verified `~/.kiro/settings/mcp.json` is created with correct servers and region substitution
- Verified MCP servers are loaded and usable in Kiro CLI (`/mcp list` shows servers running)
- Verified user custom MCP servers are preserved (additive merge only)
- Change is identical to PR #1230 (main branch)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
- PR #1230 (same change on main/template)

## Additional Notes
- The post-startup script file is identical between this branch and the template on main
- No logic change to existing qcli MCP setup — only adds Kiro CLI path to the target list
