### PR TITLE
Disable SMUS extensions via config instead of runtime removal

### DIFF
--- a/template/v4/dirs/etc/sagemaker/jupyter/lab/settings/page_config.json
+++ b/template/v4/dirs/etc/sagemaker/jupyter/lab/settings/page_config.json
@@ -1,0 +1,10 @@
+{
+  "disabledExtensions": {
+    "@amzn/sagemaker-data-explorer-jl-plugin:plugin": true,
+    "@amzn/sagemaker-connection-magics-jlextension:plugin": true,
+    "@amzn/sagemaker-studio-jupyter-scheduler:plugin": true,
+    "@amzn/sagemaker-ui-doc-manager-jl-plugin:plugin": true,
+    "@amzn/sagemaker-ui-theme-jlplugin:plugin": true,
+    "sagemaker_sparkmonitor:plugin": true
+  }
+}

--- a/template/v4/dirs/etc/sagemaker/jupyter/server/jupyter_server_config.d/zzz_sagemaker_overrides.json
+++ b/template/v4/dirs/etc/sagemaker/jupyter/server/jupyter_server_config.d/zzz_sagemaker_overrides.json
@@ -1,0 +1,9 @@
+{
+  "ServerApp": {
+    "jpserver_extensions": {
+      "sagemaker_studio_jupyter_scheduler": false,
+      "sagemaker_jupyter_server_extension": false,
+      "panel.io.jupyter_server_extension": false
+    }
+  }
+}

--- a/template/v4/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/dirs/usr/local/bin/start-jupyter-server
@@ -10,10 +10,22 @@ if [ -n "$SAGEMAKER_RECOVERY_MODE" ]; then
 else
     # Activate conda environment 'base'
     micromamba activate base
-    # Uninstall SMUS-specific extensions
-    micromamba remove -y sagemaker-studio-dataengineering-sessions sagemaker-studio-dataengineering-extensions
-    # Disable SMUS-specific extensions
-    jupyter labextension disable sagemaker-data-explorer:plugin
+
+    # Disable SMUS server extensions
+    cp /etc/sagemaker/jupyter/server/jupyter_server_config.d/zzz_sagemaker_overrides.json /opt/conda/etc/jupyter/jupyter_server_config.d/
+
+    # Prevent SMUS lab extensions from loading
+    for ext in \
+        /opt/conda/share/jupyter/labextensions/@amzn/sagemaker-data-explorer-jl-plugin \
+        /opt/conda/share/jupyter/labextensions/@amzn/sagemaker-connection-magics-jlextension \
+        /opt/conda/share/jupyter/labextensions/@amzn/sagemaker-studio-jupyter-scheduler \
+        /opt/conda/share/jupyter/labextensions/@amzn/sagemaker-ui-doc-manager-jl-plugin \
+        /opt/conda/share/jupyter/labextensions/@amzn/sagemaker-ui-theme-jlplugin \
+        /opt/conda/share/jupyter/labextensions/sagemaker_sparkmonitor \
+        /opt/conda/share/jupyter/labextensions/@pyviz/jupyterlab_pyviz \
+        /opt/conda/share/jupyter/labextensions/@amzn/sagemaker_post_startup_notification_plugin; do
+      [ -f "$ext/package.json" ] && mv "$ext/package.json" "$ext/package.json.disabled"
+    done
 fi
 
 # Setup skills and subagent for SMAI private spaces only


### PR DESCRIPTION
## Summary
- Replace runtime `micromamba remove` and `jupyter labextension disable` in `start-jupyter-server` with a static config-based approach that avoids modifying the conda environment at startup
- Add `page_config.json` to disable 6 SMUS lab extensions via JupyterLab page settings
- Add `zzz_sagemaker_overrides.json` to disable 3 SMUS server extensions via Jupyter server config
- Update `start-jupyter-server` to copy the server config override and rename `package.json` files to prevent unwanted lab extensions from loading
