### PR TITLE
Add aws-smus-cicd-cli to SageMaker Distribution v4.3

### DIFF
--- a/build_artifacts/v4/v4.3/v4.3.0/cpu.additional_packages_env.in
+++ b/build_artifacts/v4/v4.3/v4.3.0/cpu.additional_packages_env.in
@@ -1,0 +1,1 @@
+conda-forge::aws-smus-cicd-cli[version='>=1.0.5,<2.0.0']

--- a/build_artifacts/v4/v4.3/v4.3.0/gpu.additional_packages_env.in
+++ b/build_artifacts/v4/v4.3/v4.3.0/gpu.additional_packages_env.in
@@ -1,0 +1,1 @@
+conda-forge::aws-smus-cicd-cli[version='>=1.0.5,<2.0.0']

--- a/test/test_artifacts/v4/aws-smus-cicd-cli.test.Dockerfile
+++ b/test/test_artifacts/v4/aws-smus-cicd-cli.test.Dockerfile
@@ -1,0 +1,9 @@
+ARG SAGEMAKER_DISTRIBUTION_IMAGE
+FROM $SAGEMAKER_DISTRIBUTION_IMAGE
+
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+
+COPY --chown=$MAMBA_USER:$MAMBA_USER scripts/run_aws_smus_cicd_cli_tests.sh ./
+RUN chmod +x run_aws_smus_cicd_cli_tests.sh
+
+CMD ["./run_aws_smus_cicd_cli_tests.sh"]

--- a/test/test_artifacts/v4/scripts/run_aws_smus_cicd_cli_tests.sh
+++ b/test/test_artifacts/v4/scripts/run_aws_smus_cicd_cli_tests.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Check if aws-smus-cicd-cli is installed
+function check_cli_installed {
+    if ! command -v aws-smus-cicd-cli &> /dev/null; then
+        echo "aws-smus-cicd-cli is not installed."
+        exit 1
+    else
+        echo "aws-smus-cicd-cli is installed."
+    fi
+}
+
+# Check if the CLI can create a manifest file
+function check_cli_create {
+    local output_file="/tmp/test-manifest.yaml"
+    if aws-smus-cicd-cli create --output "$output_file" --name TestPipeline; then
+        echo "aws-smus-cicd-cli create succeeded."
+    else
+        echo "aws-smus-cicd-cli create failed."
+        exit 1
+    fi
+
+    if [ -f "$output_file" ]; then
+        echo "Manifest file created successfully at $output_file."
+    else
+        echo "Manifest file was not created."
+        exit 1
+    fi
+
+    # Clean up
+    rm -f "$output_file"
+}
+
+# Run the checks
+check_cli_installed
+check_cli_create
+echo "aws-smus-cicd-cli validation successful."

--- a/test/test_dockerfile_based_harness.py
+++ b/test/test_dockerfile_based_harness.py
@@ -82,6 +82,7 @@ _docker_client = docker.from_env()
         ("sm_spark_cli.test.Dockerfile", []),
         ("sagemaker_studio.integ.Dockerfile", ["sagemaker_studio"]),
         ("strands.test.Dockerfile", ["strands-agents"]),
+        ("aws-smus-cicd-cli.test.Dockerfile", ["aws-smus-cicd-cli"]),
     ],
 )
 def test_dockerfiles_for_cpu(
@@ -167,6 +168,7 @@ def test_dockerfiles_for_cpu(
         ("sm_spark_cli.test.Dockerfile", []),
         ("sagemaker_studio.integ.Dockerfile", ["sagemaker_studio"]),
         ("strands.test.Dockerfile", ["strands-agents"]),
+        ("aws-smus-cicd-cli.test.Dockerfile", ["aws-smus-cicd-cli"]),
     ],
 )
 def test_dockerfiles_for_gpu(


### PR DESCRIPTION
## Summary

Adds `aws-smus-cicd-cli` (the CI/CD CLI for Amazon SageMaker Unified Studio) as an additional package in SageMaker Distribution v4.3 for both CPU and GPU environments.

**Package:** [aws-smus-cicd-cli on Conda Forge](https://anaconda.org/conda-forge/aws-smus-cicd-cli) (v1.0.5, noarch)
**Feedstock:** https://github.com/conda-forge/aws-smus-cicd-cli-feedstock

## Changes

- `build_artifacts/v4/v4.3/v4.3.0/cpu.additional_packages_env.in` — added aws-smus-cicd-cli
- `build_artifacts/v4/v4.3/v4.3.0/gpu.additional_packages_env.in` — added aws-smus-cicd-cli
- `test/test_artifacts/v4/aws-smus-cicd-cli.test.Dockerfile` — test Dockerfile
- `test/test_artifacts/v4/scripts/run_aws_smus_cicd_cli_tests.sh` — validates CLI is installed and can create a manifest
- `test/test_dockerfile_based_harness.py` — registered test for CPU and GPU

## Test Results

The new `aws-smus-cicd-cli` test **passes**:
```
[gw2] [ 84%] PASSED test/test_dockerfile_based_harness.py::test_dockerfiles_for_cpu[aws-smus-cicd-cli.test.Dockerfile-required_packages49]
```

<details>
<summary>Full CPU test suite results (50 tests: 33 passed, 12 failed, 5 skipped)</summary>

| Test | Result |
|------|--------|
| anaconda.test.Dockerfile | ✅ PASSED |
| keras.test.Dockerfile | ✅ PASSED |
| autogluon.test.Dockerfile | ✅ PASSED |
| matplotlib.test.Dockerfile (required_packages3) | ✅ PASSED |
| matplotlib.test.Dockerfile (required_packages4) | ✅ PASSED |
| sagemaker-headless-execution-driver.test.Dockerfile | ✅ PASSED |
| scipy.test.Dockerfile | ❌ FAILED |
| numpy.test.Dockerfile | ✅ PASSED |
| boto3.test.Dockerfile | ❌ FAILED |
| pandas.test.Dockerfile | ❌ FAILED |
| sm-python-sdk.test.Dockerfile | ❌ FAILED |
| pytorch.examples.Dockerfile | ❌ FAILED |
| tensorflow.examples.Dockerfile | ✅ PASSED |
| jupyter-ai.test.Dockerfile | ✅ PASSED |
| jupyter-collaboration.test.Dockerfile | ❌ FAILED |
| jupyter-dash.test.Dockerfile | ✅ PASSED |
| jupyterlab-lsp.test.Dockerfile | ✅ PASSED |
| python-lsp-server.test.Dockerfile | ✅ PASSED |
| sagemaker-code-editor.test.Dockerfile | ✅ PASSED |
| notebook.test.Dockerfile | ✅ PASSED |
| glue-sessions.test.Dockerfile | ✅ PASSED |
| altair.test.Dockerfile | ✅ PASSED |
| sagemaker-studio-analytics-extension.test.Dockerfile | ✅ PASSED |
| amazon-codewhisperer-jupyterlab-ext.test.Dockerfile | ⏭️ SKIPPED |
| jupyterlab-git.test.Dockerfile | ❌ FAILED |
| amazon-sagemaker-sql-magic.test.Dockerfile | ✅ PASSED |
| amazon_sagemaker_sql_editor.test.Dockerfile | ✅ PASSED |
| langchain.test.Dockerfile | ✅ PASSED |
| langchain-aws.test.Dockerfile | ✅ PASSED |
| mlflow.test.Dockerfile | ❌ FAILED |
| jupyter-activity-monitor-extension.test.Dockerfile | ✅ PASSED |
| docker-cli.test.Dockerfile | ✅ PASSED |
| s3fs.test.Dockerfile | ✅ PASSED |
| seaborn.test.Dockerfile | ❌ FAILED |
| sagemaker-recovery-mode.test.Dockerfile | ✅ PASSED |
| jinja2.test.Dockerfile | ✅ PASSED |
| uvicorn.test.Dockerfile | ❌ FAILED |
| fastapi.test.Dockerfile | ❌ FAILED |
| scikit-learn.test.Dockerfile | ✅ PASSED |
| jupyter-scheduler.test.Dockerfile | ✅ PASSED |
| jupyter-server-proxy.test.Dockerfile | ✅ PASSED |
| ipywidgets.test.Dockerfile | ✅ PASSED |
| supervisor.test.Dockerfile | ✅ PASSED |
| xgboost-cpu.test.Dockerfile | ❌ FAILED |
| sagemaker_studio.test.Dockerfile | ⏭️ SKIPPED |
| sagemaker_studio_cli.test.Dockerfile | ⏭️ SKIPPED |
| sm_spark_cli.test.Dockerfile | ⏭️ SKIPPED |
| sagemaker_studio.integ.Dockerfile | ⏭️ SKIPPED |
| strands.test.Dockerfile | ✅ PASSED |
| **aws-smus-cicd-cli.test.Dockerfile** | ✅ **PASSED** |

**Note:** The 12 failures are pre-existing and unrelated to this change (they involve network-dependent tests like git clones, upstream test suite issues, etc.).
</details>
