### PR TITLE
Add ray to SageMaker Distribution v4.3

### DIFF
--- a/build_artifacts/v4/v4.3/v4.3.0/cpu.additional_packages_env.in
+++ b/build_artifacts/v4/v4.3/v4.3.0/cpu.additional_packages_env.in
@@ -1,1 +1,2 @@
 conda-forge::aws-smus-cicd-cli[version='>=1.0.5,<2.0.0']
+conda-forge::ray-default[version='>=2.53.0,<3.0.0']

--- a/build_artifacts/v4/v4.3/v4.3.0/gpu.additional_packages_env.in
+++ b/build_artifacts/v4/v4.3/v4.3.0/gpu.additional_packages_env.in
@@ -1,1 +1,2 @@
 conda-forge::aws-smus-cicd-cli[version='>=1.0.5,<2.0.0']
+conda-forge::ray-default[version='>=2.53.0,<3.0.0']

--- a/test/test_artifacts/v4/ray.test.Dockerfile
+++ b/test/test_artifacts/v4/ray.test.Dockerfile
@@ -1,0 +1,6 @@
+ARG SAGEMAKER_DISTRIBUTION_IMAGE
+FROM $SAGEMAKER_DISTRIBUTION_IMAGE
+
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+
+CMD ["python", "-c", "import ray; ray.init(local_mode=True); print(ray.__version__); ray.shutdown()"]

--- a/test/test_dockerfile_based_harness.py
+++ b/test/test_dockerfile_based_harness.py
@@ -83,6 +83,7 @@ _docker_client = docker.from_env()
         ("sagemaker_studio.integ.Dockerfile", ["sagemaker_studio"]),
         ("strands.test.Dockerfile", ["strands-agents"]),
         ("aws-smus-cicd-cli.test.Dockerfile", ["aws-smus-cicd-cli"]),
+        ("ray.test.Dockerfile", ["ray-default"]),
     ],
 )
 def test_dockerfiles_for_cpu(
@@ -169,6 +170,7 @@ def test_dockerfiles_for_cpu(
         ("sagemaker_studio.integ.Dockerfile", ["sagemaker_studio"]),
         ("strands.test.Dockerfile", ["strands-agents"]),
         ("aws-smus-cicd-cli.test.Dockerfile", ["aws-smus-cicd-cli"]),
+        ("ray.test.Dockerfile", ["ray-default"]),
     ],
 )
 def test_dockerfiles_for_gpu(


### PR DESCRIPTION
## What
Add `ray` (`ray-default`) as an explicit top-level dependency of SageMaker Distribution v4.3, for both CPU and GPU images.

Today `ray` is only present transitively (pulled in by `autogluon`). This promotes it to a first-class, version-tracked package so it stays in the image on its own.

## How
- Add `conda-forge::ray-default[version='>=2.53.0,<3.0.0']` to `cpu.additional_packages_env.in` and `gpu.additional_packages_env.in` under `build_artifacts/v4/v4.3/v4.3.0/`.
- Add `test/test_artifacts/v4/ray.test.Dockerfile` (imports `ray` and runs `ray.init(local_mode=True)`), registered in the CPU and GPU lists in `test/test_dockerfile_based_harness.py`.

The floor is pinned to `>=2.53.0` because `autogluon 1.5.0` (already in the image) requires `ray-default <2.54`, so `2.53.0` is the current compatible version; anything higher fails to solve. `<3.0.0` caps at the next major.

Per CONTRIBUTING.md step 8, only the `additional_packages_env.in` files and test files are included; `env.in`/`env.out`/`Dockerfile` are regenerated by maintainers/CI.

## Testing
Built both images locally end-to-end via `python ./src/main.py build --target-patch-version=4.3.0`:
- **CPU** image built successfully (`4.3.0-cpu`); `env.out` resolves `ray-default-2.53.0`.
- **GPU** image built successfully (`4.3.0-gpu`).

The environment solves cleanly with `ray-default` promoted to a top-level dependency, co-existing with `autogluon` at the compatible `2.53.0`.
