### PR TITLE
chore(v4): Remove amazon-q-vscode from SMUS Code Editor

### DIFF
--- a/template/v4/dirs/etc/code-editor/extensions-sagemaker-ui.txt
+++ b/template/v4/dirs/etc/code-editor/extensions-sagemaker-ui.txt
@@ -1,4 +1,3 @@
 https://open-vsx.org/api/ms-toolsai/jupyter/2024.5.0/file/ms-toolsai.jupyter-2024.5.0.vsix
 https://open-vsx.org/api/ms-python/python/2026.2.0/file/ms-python.python-2026.2.0.vsix
 https://open-vsx.org/api/amazonwebservices/aws-toolkit-vscode/3.101.0/file/amazonwebservices.aws-toolkit-vscode-3.101.0.vsix
-https://open-vsx.org/api/amazonwebservices/amazon-q-vscode/2.0.0/file/amazonwebservices.amazon-q-vscode-2.0.0.vsix


### PR DESCRIPTION
## Description
Remove the Amazon Q extension (`amazon-q-vscode`) from the SMUS (`sagemaker-ui`) Code Editor extension list as part of the SMUS Amazon Q deprecation. `aws-toolkit-vscode` (AWS Toolkit, not Q) is kept.

**Scope: SMUS only — this does NOT affect SageMaker AI (SMAI).** This edits `extensions-sagemaker-ui.txt`, which installs into the separate `sagemaker-ui-code-editor-server-data` dir used by the SMUS Code Editor. The standalone SMAI Code Editor installs from `extensions.txt` (`sagemaker-code-editor-server-data`), which is unchanged and still includes `amazon-q-vscode`.

Lands in the next 4.x minor build (4.3+); released 4.0–4.2 patch lines are unaffected (SemVer: patch releases do not add or remove packages).

## Type of Change
- [ ] Image update - Bug fix
- [x] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ ] Yes (Critical bug fix or security update)
- [x] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
N/A — this is an intentional package removal and must ship as a new minor (4.3+), not a patch. Per the SMD support policy, patch releases do not add or remove packages; removing the VSIX from an existing minor would be a backwards-incompatible change.

## How Has This Been Tested?
Validated by building the v4 image and launching Code Editor:
- SMUS Code Editor (`sagemaker-ui-code-editor-server-data`): `amazon-q-vscode` is no longer installed; `aws-toolkit-vscode`, Python, and Jupyter extensions remain.
- Standalone SMAI Code Editor (`sagemaker-code-editor-server-data`): unaffected — `amazon-q-vscode` still present (installed from `extensions.txt`).

## Checklist:
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):
N/A

## Related Issues
N/A (SMUS-internal Amazon Q deprecation tracking)

## Additional Notes
Single-line change to `template/v4/dirs/etc/code-editor/extensions-sagemaker-ui.txt` (one deletion). No build-tool, settings, or documentation changes. The two extension lists install into separate server-data directories, which is what scopes this to SMUS without touching SMAI.