### PR TITLE
Allow pre-created minor templates and document template workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,20 +138,18 @@ template/
 
 ### Deciding where to make your change
 
-First, identify the latest minor version's template (e.g., `template/v4/v4.3/`). Then check whether that minor version has already been released by looking for its `.0` patch in `build_artifacts/`:
+Find the latest minor version that has a template directory (e.g., `template/v4/v4.3/`). Then check whether any build artifact exists for that minor version:
 
 ```shell
-# Example: checking if v4.3 has been released
-ls build_artifacts/v4/v4.3/v4.3.0/
+# Example: checking if v4.3 has any released patch version
+ls build_artifacts/v4/v4.3/
 ```
 
-#### Adding a new feature (applies since upcoming new minor versions only)
+There are two possible states:
 
-Find the latest minor version's template directory (e.g., `template/v4/v4.3/`). Then decide:
+- **Template exists, but NO build artifact exists** (e.g., `template/v4/v4.3/` exists but `build_artifacts/v4/v4.3/` is empty or does not exist): this minor version has not been released yet. Make your changes directly in `template/v4/v4.3/`.
 
-- **If the latest minor version has NOT been released** (e.g., `build_artifacts/v4/v4.3/v4.3.0/` does not exist): edit the latest minor's template directly. It doesn't matter whether the template was created by you or by someone else — as long as v4.3.0 hasn't been released, all changes for the next minor go into `template/v4/v4.3/`.
-
-- **If the latest minor version has already been released** (e.g., `build_artifacts/v4/v4.3/v4.3.0/` exists): create a new minor version's template by copying from the latest, then make your changes there:
+- **Template exists AND build artifacts exist** (e.g., both `template/v4/v4.3/` and `build_artifacts/v4/v4.3/v4.3.0/` exist): this minor version has already been released. Create the next minor version's template by copying from it, then make your changes in the new template:
 
   ```shell
   cp -r template/v4/v4.3 template/v4/v4.4
@@ -160,19 +158,15 @@ Find the latest minor version's template directory (e.g., `template/v4/v4.3/`). 
 
   Include the new template directory in your PR.
 
-In either case, older minor versions (4.0, 4.1, 4.2) are unaffected. Their next patch release will continue using their own frozen template.
+#### Adding a new feature (applies to upcoming minor versions only)
 
-Note: Since future minor versions are created by copying from the previous minor's template, any change made to the latest unreleased minor's template will also be inherited by subsequent minor versions when they are created.
+Follow the decision above to identify the correct unreleased minor template, and make your changes there. Older released minor versions are unaffected — their next patch release will continue using their own frozen template.
+
+Since future minor versions are created by copying from the previous minor's template, any change made to an unreleased minor's template will also be inherited by subsequent minor versions when they are created (If you make change to template/v4/v4.4/, template/v4/v4.5/ and template/v4/v4.6/ will also get the change).
 
 #### Applying a security fix or infrastructure change (applies to all supported minor versions)
 
-If the latest minor version has already been released, first create the next minor version's template:
-
-```shell
-cp -r template/v4/v4.3 template/v4/v4.4
-```
-
-Then apply the fix to **all** supported minor version templates (including the newly created one):
+Follow the decision above — if the latest minor has been released, create the next minor version's template first. Then apply the fix to **all** supported minor version templates (including the newly created one):
 
 ```
 template/v4/v4.0/Dockerfile
@@ -181,8 +175,6 @@ template/v4/v4.2/Dockerfile
 template/v4/v4.3/Dockerfile
 template/v4/v4.4/Dockerfile
 ```
-
-If the latest minor version has NOT been released yet, simply apply the fix to all existing supported minor version templates.
 
 This approach is intentional — it makes the scope of the fix auditable and prevents accidental feature leakage.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,41 +136,59 @@ template/
     └── v4.3/
 ```
 
-### Adding a new feature to a specific minor version
+### Deciding where to make your change
 
-If the change should only apply to a specific minor version (e.g., v4.3), edit only that minor's template:
+First, identify the latest minor version's template (e.g., `template/v4/v4.3/`). Then check whether that minor version has already been released by looking for its `.0` patch in `build_artifacts/`:
 
+```shell
+# Example: checking if v4.3 has been released
+ls build_artifacts/v4/v4.3/v4.3.0/
 ```
-template/v4/v4.3/Dockerfile
-template/v4/v4.3/dirs/
+
+#### Adding a new feature (applies since upcoming new minor versions only)
+
+Find the latest minor version's template directory (e.g., `template/v4/v4.3/`). Then decide:
+
+- **If the latest minor version has NOT been released** (e.g., `build_artifacts/v4/v4.3/v4.3.0/` does not exist): edit the latest minor's template directly. It doesn't matter whether the template was created by you or by someone else — as long as v4.3.0 hasn't been released, all changes for the next minor go into `template/v4/v4.3/`.
+
+- **If the latest minor version has already been released** (e.g., `build_artifacts/v4/v4.3/v4.3.0/` exists): create a new minor version's template by copying from the latest, then make your changes there:
+
+  ```shell
+  cp -r template/v4/v4.3 template/v4/v4.4
+  # Now edit template/v4/v4.4/ as needed
+  ```
+
+  Include the new template directory in your PR.
+
+In either case, older minor versions (4.0, 4.1, 4.2) are unaffected. Their next patch release will continue using their own frozen template.
+
+Note: Since future minor versions are created by copying from the previous minor's template, any change made to the latest unreleased minor's template will also be inherited by subsequent minor versions when they are created.
+
+#### Applying a security fix or infrastructure change (applies to all supported minor versions)
+
+If the latest minor version has already been released, first create the next minor version's template:
+
+```shell
+cp -r template/v4/v4.3 template/v4/v4.4
 ```
 
-Other old minor versions(4.0, 4.1 or 4.2) are unaffected. Their next patch release will continue using their own frozen template.
-
-Note: Since future minor versions (e.g., v4.4) are created by copying from the previous minor's template (v4.3), any change made to v4.3's template will also be inherited by v4.4 and beyond when they are created.
-
-### Applying a security fix or infrastructure change across all active minor versions
-
-If the change must propagate to all supported minor versions (e.g., a Dockerfile security patch), apply it to each per-minor template explicitly:
+Then apply the fix to **all** supported minor version templates (including the newly created one):
 
 ```
 template/v4/v4.0/Dockerfile
 template/v4/v4.1/Dockerfile
 template/v4/v4.2/Dockerfile
 template/v4/v4.3/Dockerfile
+template/v4/v4.4/Dockerfile
 ```
 
-This is intentional — it makes the scope of the fix auditable and prevents accidental feature leakage.
+If the latest minor version has NOT been released yet, simply apply the fix to all existing supported minor version templates.
 
-### How new minor versions are created
+This approach is intentional — it makes the scope of the fix auditable and prevents accidental feature leakage.
 
-When `create-minor-version-artifacts` is run (e.g., creating v4.4 from v4.3.x), the tooling automatically copies the previous minor's template to create the new one:
+### How new minor version templates are auto-created at build time
 
-```
-template/v4/v4.3/  →  template/v4/v4.4/
-```
-
-You can then edit `template/v4/v4.4/` to add or remove features specific to the new minor version before building it.
+If no one creates the template directory before `create-minor-version-artifacts` runs, the tooling will automatically copy it from the previous minor's template (e.g., v4.3 → v4.4). This means any change in v4.3's template will be inherited by v4.4 if its template hasn't been pre-created.
 
 
 ## Finding contributions to work on

--- a/src/main.py
+++ b/src/main.py
@@ -75,22 +75,21 @@ def _delete_all_files_except_additional_packages_input_files(base_version_dir, v
 
 
 def _ensure_minor_template_exists(version: Version):
-    """Create the per-minor template directory for a new minor/major version.
+    """Ensure the per-minor template directory exists for a new minor/major version.
 
-    Copies Dockerfile and dirs/ from the previous minor's template directory
-    (e.g. template/v4/v4.2/ -> template/v4/v4.3/). This is the snapshot that
-    all future patch releases of this minor will use.
+    If the directory already exists (e.g. a contributor pre-created it with
+    feature changes), it is left as-is. Otherwise, copies from the previous
+    minor's template (e.g. template/v4/v4.2/ -> template/v4/v4.3/).
 
-    For the first minor of a new major version (minor == 0), the caller must
-    ensure template/v{major}/v{major}.0/ is set up manually since there is no
-    previous minor to copy from.
+    For the first minor of a new major version (minor == 0), the directory must
+    be created manually since there is no previous minor to copy from.
     """
     major = version.major
     minor = version.minor
     minor_template_dir = f"template/v{major}/v{major}.{minor}"
 
     if os.path.exists(minor_template_dir):
-        shutil.rmtree(minor_template_dir)
+        return
 
     if minor == 0:
         raise Exception(


### PR DESCRIPTION
## Description
Allow pre-created minor templates and document template workflow
1. Not overriding a minor version template folder if it already exists, instead we expect human modification only
2. Update CONTRIBUTING.md accordingly, with instructions telling what to do when making change for new feature(apply since new minor version only), what to do when making change for security patch(apply for all new minor and patch versions)
  - Expect contributor to copy/paste to create new minor version's template folder, and then make change there 

## Type of Change
- [ ] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [x] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ ] Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [x] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]

## How Has This Been Tested?
Tested build artifact generation, verified one minor version's template folder won't be overridden once it's created already.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
[Link any related issues here]

## Additional Notes
[Any additional information that might be helpful for reviewers]
