### PR TITLE
Disable SMUS extensions via config in 4.1.6 release

### DIFF
--- a/build_artifacts/v4/v4.1/v4.1.6/dirs/etc/sagemaker/jupyter/server/jupyter_server_config.d/zzz_sagemaker_overrides.json
+++ b/build_artifacts/v4/v4.1/v4.1.6/dirs/etc/sagemaker/jupyter/server/jupyter_server_config.d/zzz_sagemaker_overrides.json
@@ -1,0 +1,9 @@
+{
+  "ServerApp": {
+    "jpserver_extensions": {
+      "sagemaker_studio_jupyter_scheduler": false,
+      "sagemaker_jupyter_server_extension": false,
+      "panel.io.jupyter_server_extension": false
+    }
+  }
+}

--- a/build_artifacts/v4/v4.1/v4.1.6/dirs/usr/local/bin/start-jupyter-server
+++ b/build_artifacts/v4/v4.1/v4.1.6/dirs/usr/local/bin/start-jupyter-server
@@ -10,10 +10,18 @@ if [ -n "$SAGEMAKER_RECOVERY_MODE" ]; then
 else
     # Activate conda environment 'base'
     micromamba activate base
-    # Uninstall SMUS-specific extensions
-    micromamba remove -y sagemaker-studio-dataengineering-sessions sagemaker-studio-dataengineering-extensions
-    # Disable SMUS-specific extensions
-    jupyter labextension disable sagemaker-data-explorer:plugin
+    # Disable SMUS server extensions
+    cp /etc/sagemaker/jupyter/server/jupyter_server_config.d/zzz_sagemaker_overrides.json /opt/conda/etc/jupyter/jupyter_server_config.d/
+
+    # Prevent SMUS lab extensions from loading
+    rm -f /opt/conda/share/jupyter/labextensions/@amzn/sagemaker-data-explorer-jl-plugin/package.json \
+        /opt/conda/share/jupyter/labextensions/@amzn/sagemaker-connection-magics-jlextension/package.json \
+        /opt/conda/share/jupyter/labextensions/@amzn/sagemaker-studio-jupyter-scheduler/package.json \
+        /opt/conda/share/jupyter/labextensions/@amzn/sagemaker-ui-doc-manager-jl-plugin/package.json \
+        /opt/conda/share/jupyter/labextensions/@amzn/sagemaker-ui-theme-jlplugin/package.json \
+        /opt/conda/share/jupyter/labextensions/sagemaker_sparkmonitor/package.json \
+        /opt/conda/share/jupyter/labextensions/@pyviz/jupyterlab_pyviz/package.json \
+        /opt/conda/share/jupyter/labextensions/@amzn/sagemaker_post_startup_notification_plugin/package.json
 fi
 
 # Setup skills and subagent for SMAI private spaces only


### PR DESCRIPTION
## Summary
- Reapply changes from a3a4b975 and 8bdfda37 to the 4.1.6 release branch
- Replace runtime `micromamba remove` + `jupyter labextension disable` with static server config and `rm -f` of extension package.json files
- Add `zzz_sagemaker_overrides.json` to disable server extensions via config
