### PR TITLE
feat: Install Teradata driver on post-startup for v4.2

### DIFF
--- a/template/v4/v4.2/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/template/v4/v4.2/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -449,6 +449,12 @@ if [ "${SAGEMAKER_APP_TYPE_LOWERCASE}" = "jupyterlab" ] && [ "$is_express_mode" 
 
     # Install sm-spark-cli
     bash /etc/sagemaker-ui/workflows/sm-spark-cli-install.sh || echo "Warning: sm-spark-cli installation failed, continuing..."
+
+    # Install Teradata driver (non-blocking; not available via conda-forge).
+    # timeout + limited retries bound the delay for environments with no
+    # internet egress (e.g. fully isolated VpcOnly), where pip's default
+    # retry/backoff can otherwise take several minutes to fail out.
+    timeout 15 pip install --retries 1 teradatasql teradatasqlalchemy || echo "Warning: teradata driver installation failed or timed out, continuing..."
 fi
 
 # Execute network validation script, to check if any required AWS Services are unreachable


### PR DESCRIPTION
## Description
  Adds Teradata driver support to SageMaker Unified Studio by installing `teradatasql` and `teradatasqlalchemy` via pip during the v4.2 post-startup script, on JupyterLab space startup. This complements the Teradata connector code being added to MaxDomePythonSDK, enabling SMUS customers to run SQL cells against Teradata data sources.
  
  These packages cannot be added as a conda-forge/SMD dependency because their license is not structured for inclusion in SMD (non-Apache/non-MIT) — confirmed with the SMD team. Installing them via pip at post-startup, non-blocking, is the recommended approach for this kind of dependency (per SMD team guidance).
  
 ## Type of Change
  - [x] Image update - New feature
  
 ## Release Information
  - [x] No (New feature or non-critical change)
  
 ## How Has This Been Tested?
  - End-to-end BYOI test in a SMUS gamma domain: built a custom image combining this post-startup change with MaxDomePythonSDK's Teradata connector code (CR-250210917), launched a JupyterLab space, and confirmed `sqlutils.sql_stream_with_display()` successfully connects to and queries a live Teradata instance.
  - Verified the driver install succeeds normally in `VpcOnly` domains with a NAT Gateway (SMUS's default network configuration).
  - Verified behavior in a fully isolated `VpcOnly` VPC with no internet egress (no NAT Gateway/Internet Gateway): confirmed the unbounded `pip install` call takes several minutes to fail out via pip's default retry/backoff before the non-blocking fallback (`|| echo "Warning: ..."`) kicks in. Added `timeout 15` and `--retries 1` to bound this to ~15 seconds instead, based on real measured successful-install times (3-5 seconds in working-egress environments).
  - Verified shell syntax (`bash -n`) on the modified script.
  
  ## Checklist:
  - [x] My code follows the style guidelines of this project
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  
  ## Related Issues
  Related to CR-250210917 (MaxDomePythonSDK Teradata connector support)
  
  ## Additional Notes
  This change only targets `v4.2` (the current latest template at time of authoring). A `v4.3` template did not yet exist in the repo when this was scoped; if `v4.3`'s template is created as a fresh copy rather than inheriting from `v4.2`, this same change will need to be replicated there separately.