### PR TITLE
docs: Move 2.13.x and 3.8.x to Unsupported (EOS Aug 1st, 2026)

### DIFF
--- a/support_policy.md
+++ b/support_policy.md
@@ -34,9 +34,7 @@ The tables below lists the supported SageMaker Distribution image versions and t
 | 4.1.x         | public.ecr.aws/sagemaker/sagemaker-distribution:4.1-cpu  |  Oct 29th, 2026  |
 | 4.0.x         | public.ecr.aws/sagemaker/sagemaker-distribution:4.0-cpu  |  Oct 7th, 2026  |
 | 3.9.x         | public.ecr.aws/sagemaker/sagemaker-distribution:3.9-cpu  |  Sep 29th, 2026  |
-| 3.8.x         | public.ecr.aws/sagemaker/sagemaker-distribution:3.8-cpu  |  Aug 1st, 2026  |
 | 2.14.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.14-cpu  |  Sep 9th, 2026  |
-| 2.13.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.13-cpu  |  Aug 1st, 2026  |
 
 ### GPU Images
 
@@ -47,9 +45,7 @@ The tables below lists the supported SageMaker Distribution image versions and t
 | 4.1.x         | public.ecr.aws/sagemaker/sagemaker-distribution:4.1-gpu  |  Oct 29th, 2026  |
 | 4.0.x         | public.ecr.aws/sagemaker/sagemaker-distribution:4.0-gpu  |  Oct 7th, 2026  |
 | 3.9.x         | public.ecr.aws/sagemaker/sagemaker-distribution:3.9-gpu  |  Sep 29th, 2026  |
-| 3.8.x         | public.ecr.aws/sagemaker/sagemaker-distribution:3.8-gpu  |  Aug 1st, 2026  |
 | 2.14.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.14-gpu  |  Sep 9th, 2026  |
-| 2.13.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.13-gpu  |  Aug 1st, 2026  |
 
 
 ## Unsupported Image Versions
@@ -59,6 +55,7 @@ The tables below list SageMaker Distribution Image versions that are no longer s
 
 | Image Version | ECR Image URI | End of Support Date |
 | :---:         | :---:         | :---:               |
+| 3.8.x         | public.ecr.aws/sagemaker/sagemaker-distribution:3.8-cpu  |  Aug 1st, 2026  |
 | 3.7.x         | public.ecr.aws/sagemaker/sagemaker-distribution:3.7-cpu  |  Jun 22nd, 2026  |
 | 3.6.x         | public.ecr.aws/sagemaker/sagemaker-distribution:3.6-cpu  |  May 14th, 2026  |
 | 3.5.x         | public.ecr.aws/sagemaker/sagemaker-distribution:3.5-cpu  |  Apr 26th, 2026  |
@@ -67,6 +64,7 @@ The tables below list SageMaker Distribution Image versions that are no longer s
 | 3.2.x         | public.ecr.aws/sagemaker/sagemaker-distribution:3.2-cpu  | Dec  4th, 2025  |
 | 3.1.x         | public.ecr.aws/sagemaker/sagemaker-distribution:3.1-cpu  | Nov 19th, 2025  |
 | 3.0.x         | public.ecr.aws/sagemaker/sagemaker-distribution:3.0-cpu  | Jun 30th, 2025  |
+| 2.13.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.13-cpu  |  Aug 1st, 2026  |
 | 2.12.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.12-cpu  |  Jun 22nd, 2026  |
 | 2.11.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.11-cpu  |  May 14th, 2026  |
 | 2.10.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.10-cpu  |  Apr 26th, 2026  |
@@ -104,6 +102,7 @@ The tables below list SageMaker Distribution Image versions that are no longer s
 ### GPU Images
 | Image Version | ECR Image URI | End of Support Date |
 | :---:         | :---:         | :---:               |
+| 3.8.x         | public.ecr.aws/sagemaker/sagemaker-distribution:3.8-gpu  |  Aug 1st, 2026  |
 | 3.7.x         | public.ecr.aws/sagemaker/sagemaker-distribution:3.7-gpu  |  Jun 22nd, 2026  |
 | 3.6.x         | public.ecr.aws/sagemaker/sagemaker-distribution:3.6-gpu  |  May 14th, 2026  |
 | 3.5.x         | public.ecr.aws/sagemaker/sagemaker-distribution:3.5-gpu  |  Apr 26th, 2026  |
@@ -112,6 +111,7 @@ The tables below list SageMaker Distribution Image versions that are no longer s
 | 3.2.x         | public.ecr.aws/sagemaker/sagemaker-distribution:3.2-gpu  | Dec  4th, 2025  |
 | 3.1.x         | public.ecr.aws/sagemaker/sagemaker-distribution:3.1-gpu  | Nov 19th, 2025  |
 | 3.0.x         | public.ecr.aws/sagemaker/sagemaker-distribution:3.0-gpu  | Jun 30th, 2025  |
+| 2.13.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.13-gpu  |  Aug 1st, 2026  |
 | 2.12.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.12-gpu  |  Jun 22nd, 2026  |
 | 2.11.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.11-gpu  |  May 14th, 2026  |
 | 2.10.x         | public.ecr.aws/sagemaker/sagemaker-distribution:2.10-gpu  |  Apr 26th, 2026  |


### PR DESCRIPTION
Both 2.13.x and 3.8.x reached End of Support on Aug 1st, 2026. Move them from the Supported Image Versions tables to the Unsupported Image Versions tables.

**Changes:**
- Remove 3.8.x and 2.13.x from Supported CPU/GPU tables
- Add 3.8.x and 2.13.x to Unsupported CPU/GPU tables (sorted by EOS date)

Related: MCM-154164248