### PR TITLE
Add ray toolkit and JupyterLab extension to SageMaker Distribution v4.4

### DIFF
--- a/build_artifacts/v4/v4.4/v4.4.0/cpu.additional_packages_env.in
+++ b/build_artifacts/v4/v4.4/v4.4.0/cpu.additional_packages_env.in
@@ -1,0 +1,2 @@
+conda-forge::toolkit-for-ray-on-sagemaker-ai
+conda-forge::extension-ray-jupyterlab-sagemaker-ai

--- a/build_artifacts/v4/v4.4/v4.4.0/gpu.additional_packages_env.in
+++ b/build_artifacts/v4/v4.4/v4.4.0/gpu.additional_packages_env.in
@@ -1,0 +1,2 @@
+conda-forge::toolkit-for-ray-on-sagemaker-ai
+conda-forge::extension-ray-jupyterlab-sagemaker-ai

--- a/test/test_artifacts/v4/extension-ray-jupyterlab-sagemaker-ai.test.Dockerfile
+++ b/test/test_artifacts/v4/extension-ray-jupyterlab-sagemaker-ai.test.Dockerfile
@@ -1,0 +1,6 @@
+ARG SAGEMAKER_DISTRIBUTION_IMAGE
+FROM $SAGEMAKER_DISTRIBUTION_IMAGE
+
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+
+CMD ["python", "-c", "import extension_ray_jupyterlab_sagemaker_ai"]

--- a/test/test_artifacts/v4/toolkit-for-ray-on-sagemaker-ai.test.Dockerfile
+++ b/test/test_artifacts/v4/toolkit-for-ray-on-sagemaker-ai.test.Dockerfile
@@ -1,0 +1,6 @@
+ARG SAGEMAKER_DISTRIBUTION_IMAGE
+FROM $SAGEMAKER_DISTRIBUTION_IMAGE
+
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+
+CMD ["python", "-c", "import toolkit_for_ray_on_sagemaker_ai"]

--- a/test/test_dockerfile_based_harness.py
+++ b/test/test_dockerfile_based_harness.py
@@ -84,6 +84,14 @@ _docker_client = docker.from_env()
         ("strands.test.Dockerfile", ["strands-agents"]),
         ("aws-smus-cicd-cli.test.Dockerfile", ["aws-smus-cicd-cli"]),
         ("ray.test.Dockerfile", ["ray-default"]),
+        (
+            "toolkit-for-ray-on-sagemaker-ai.test.Dockerfile",
+            ["toolkit-for-ray-on-sagemaker-ai"],
+        ),
+        (
+            "extension-ray-jupyterlab-sagemaker-ai.test.Dockerfile",
+            ["extension-ray-jupyterlab-sagemaker-ai"],
+        ),
     ],
 )
 def test_dockerfiles_for_cpu(
@@ -171,6 +179,14 @@ def test_dockerfiles_for_cpu(
         ("strands.test.Dockerfile", ["strands-agents"]),
         ("aws-smus-cicd-cli.test.Dockerfile", ["aws-smus-cicd-cli"]),
         ("ray.test.Dockerfile", ["ray-default"]),
+        (
+            "toolkit-for-ray-on-sagemaker-ai.test.Dockerfile",
+            ["toolkit-for-ray-on-sagemaker-ai"],
+        ),
+        (
+            "extension-ray-jupyterlab-sagemaker-ai.test.Dockerfile",
+            ["extension-ray-jupyterlab-sagemaker-ai"],
+        ),
     ],
 )
 def test_dockerfiles_for_gpu(


### PR DESCRIPTION
## Description
Adds a new minor version **v4.4.0** introducing two conda-forge packages to the CPU and GPU environments:
- `toolkit-for-ray-on-sagemaker-ai`
- `extension-ray-jupyterlab-sagemaker-ai`

Both are pure-Python and available on conda-forge. Per CONTRIBUTING, the PR contains only the delta `{cpu,gpu}.additional_packages_env.in` files plus the test Dockerfiles and `test_dockerfile_based_harness.py` registration (env.in/env.out/Dockerfile are generated at release time, not committed).

## Type of Change
- [x] Image update - New feature

## Release Information
- [x] No (New feature or non-critical change)

## How Has This Been Tested?
Generated the v4.4.0 artifacts from base 4.3.1 and built both images locally, then ran the two new import tests against the built images:

```
# generate + build (base 4.3.1 -> new minor 4.4.0)
python ./src/main.py create-minor-version-artifacts --base-patch-version=4.3.1 --force
python ./src/main.py build --target-patch-version=4.4.0 --skip-tests
#   -> BUILD_EXIT=0; images: sagemaker-distribution:4.4.0-cpu (12.1GB), 4.4.0-gpu (23.6GB)

# CPU import tests
python -m pytest -m cpu -rs --local-image-version 4.4.0 \
  -k "toolkit-for-ray-on-sagemaker-ai or extension-ray-jupyterlab-sagemaker-ai"
================ 2 passed, 185 deselected, 2 warnings in 14.50s ================

# GPU import tests
python -m pytest -m gpu -rs --local-image-version 4.4.0 \
  -k "toolkit-for-ray-on-sagemaker-ai or extension-ray-jupyterlab-sagemaker-ai"
================ 2 passed, 185 deselected, 1 warning in 12.42s =================
```

Both packages import successfully (`import toolkit_for_ray_on_sagemaker_ai`, `import extension_ray_jupyterlab_sagemaker_ai`) in both CPU and GPU images. The conda solve resolving both packages alongside the full inherited v4.3.1 environment is the compatibility check (CONTRIBUTING step 6).

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature works

## Related Issues
N/A

## Additional Notes
Follows the same structure as the v3.8.0 `langchain-openai` and v4.3.0 `aws-smus-cicd-cli` additions: `additional_packages_env.in` is delta-only (inherited base packages are merged in by the generator at build time). The existing EMR extension stays at its inherited `>=0.4.3` floor.
