### PR TITLE
Disable Amazon Q gen-AI JupyterLab extension by default in v4.4

### DIFF
--- a/template/v4/v4.4/Dockerfile
+++ b/template/v4/v4.4/Dockerfile
@@ -233,7 +233,12 @@ RUN if [[ -z $ARG_BASED_ENV_IN_FILENAME ]] ; \
     # Configure RTC - disable jupyter_collaboration by default
     jupyter labextension disable @jupyter/collaboration-extension && \
     # Disable docprovider-extension for v3 and above images
-    jupyter labextension disable @jupyter/docprovider-extension
+    jupyter labextension disable @jupyter/docprovider-extension && \
+    # Disable the Amazon Q gen-AI JupyterLab experience
+    # Server-ext disable stops _load_jupyter_server_extension -> initialize_lsp_server()
+    jupyter server extension disable sagemaker_gen_ai_jupyterlab_extension && \
+    # Labext disable removes the chat panel from the sidebar
+    jupyter labextension disable @amzn/sagemaker_gen_ai_jupyterlab_extension
 
 # Patch glue kernels to use kernel wrapper
 COPY patch_glue_pyspark.json /opt/conda/share/jupyter/kernels/glue_pyspark/kernel.json


### PR DESCRIPTION
## Description
Adds two jupyter extension disable commands to the v4 Dockerfile template, Disable both the server extension and lab extension for sagemaker_gen_ai_jupyterlab_extension. This prevents:
- The LSP server (aws-lsp-codewhisperer.js) from spawning
- The Q Helper indexer from running
- The chat panel from appearing in the JupyterLab sidebar

The extension remains installed and can be re-enabled at startup for environments that need it (e.g., SMAI spaces) via:
  jupyter server extension enable sagemaker_gen_ai_jupyterlab_extension
  jupyter labextension enable @amzn/sagemaker_gen_ai_jupyterlab_extension

## Type of Change
- [ ] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ ] Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]

## How Has This Been Tested?
[Describe the tests you ran]

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
[Link any related issues here]

## Additional Notes
[Any additional information that might be helpful for reviewers]
