### PR TITLE
chore(v4): Disable Amazon Q in Code Editor for SMAI + SMUS

### DIFF
--- a/template/v4/v4.4/dirs/usr/local/bin/start-code-editor
+++ b/template/v4/v4.4/dirs/usr/local/bin/start-code-editor
@@ -87,6 +87,7 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
       --base-path "/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
       --server-data-dir $recovery_mode_settings_folder \
       --extensions-dir ${recovery_mode_settings_folder}/extensions \
+      --disable-extension amazonwebservices.amazon-q-vscode \
       --user-data-dir /opt/amazon/sagemaker/sagemaker-code-editor-user-data
   else
     override_machine_settings
@@ -98,6 +99,7 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
       --base-path "/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
       --server-data-dir $persistent_settings_folder \
       --extensions-dir ${persistent_settings_folder}/extensions \
+      --disable-extension amazonwebservices.amazon-q-vscode \
       --user-data-dir /opt/amazon/sagemaker/sagemaker-code-editor-user-data
   fi
 else
@@ -105,5 +107,6 @@ else
     --without-connection-token \
     --server-data-dir /opt/amazon/sagemaker/sagemaker-code-editor-server-data \
     --extension-dir /opt/amazon/sagemaker/sagemaker-code-editor-server-data/extensions \
+    --disable-extension amazonwebservices.amazon-q-vscode \
     --user-data-dir /opt/amazon/sagemaker/sagemaker-code-editor-user-data
 fi

--- a/template/v4/v4.4/dirs/usr/local/bin/start-sagemaker-ui-code-editor
+++ b/template/v4/v4.4/dirs/usr/local/bin/start-sagemaker-ui-code-editor
@@ -100,11 +100,13 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
     --base-path "/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
     --server-data-dir $persistent_ebs_server_data_folder \
     --extensions-dir ${persistent_ebs_server_data_folder}/extensions \
+    --disable-extension amazonwebservices.amazon-q-vscode \
     --user-data-dir /opt/amazon/sagemaker/sagemaker-code-editor-user-data
 else
   sagemaker-code-editor --host 0.0.0.0 --port 8888 \
     --without-connection-token \
     --server-data-dir /opt/amazon/sagemaker/sagemaker-code-editor-server-data \
     --extension-dir /opt/amazon/sagemaker/sagemaker-code-editor-server-data/extensions \
+    --disable-extension amazonwebservices.amazon-q-vscode \
     --user-data-dir /opt/amazon/sagemaker/sagemaker-code-editor-user-data
 fi


### PR DESCRIPTION
## Description
Disable (do not uninstall) the `amazon-q-vscode` VS Code extension in Code Editor via the VS Code `extensions.allowed` policy in `code_editor_machine_settings.json`. That settings file is copied into both the SMAI (`sagemaker-code-editor-server-data`) and SMUS (`sagemaker-ui-code-editor-server-data`) server-data dirs, so this single edit disables Q on both surfaces. The extension stays installed on disk and can be re-enabled by setting the value to `true` or removing the key.

This mirrors the intent of #1286 (which disabled the JupyterLab gen-AI Q extension); this is the Code Editor / VS Code equivalent. It supersedes #1255, which removed Q from the SMUS manifest only (uninstall, SMUS-only).

## Type of Change
- [ ] Image update - Bug fix
- [x] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ ] Yes (Critical bug fix or security update)
- [x] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
N/A — template-only change; applies to the next minor image release and onward, no patch backport.

## How Has This Been Tested?
- Confirmed `code_editor_machine_settings.json` is valid JSON.
- Confirmed via the v4.4 `Dockerfile` that this settings file is copied into **both** server-data dirs (`sagemaker-code-editor-server-data` and `sagemaker-ui-code-editor-server-data`), so the policy applies to both SMAI and SMUS.
- Pending build-image smoke test: open Code Editor and confirm Amazon Q is installed but does not load (no Q UI), and that flipping the value to `true` re-enables it. Note: `extensions.allowed` requires the Code Editor fork to be VS Code ≥ 1.96 — please confirm the current `sagemaker-code-editor` version honors it.

## Checklist:
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues


## Additional Notes
Single-file, reversible change. Reverting = set `"amazonwebservices.amazon-q-vscode": true` or remove the `extensions.allowed` entry.