### PR TITLE
fix: use exec for jupyter lab to enable graceful shutdown

### DIFF
--- a/template/v4/v4.0/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.0/dirs/usr/local/bin/start-jupyter-server
@@ -38,7 +38,7 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   # SAGEMAKER_SPACE_TYPE_LOWERCASE flag is used to determine if the server should start
   # in real-time-collaboration mode for a given space.
-  jupyter lab --ip 0.0.0.0 --port 8888 \
+  exec jupyter lab --ip 0.0.0.0 --port 8888 \
     --ServerApp.base_url="/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
     --ServerApp.token='' \
     --ServerApp.allow_origin='*' \
@@ -50,12 +50,12 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
-  jupyter lab --ip 0.0.0.0 --port 8888 \
+  exec jupyter lab --ip 0.0.0.0 --port 8888 \
     --ServerApp.base_url="/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
     --ServerApp.token='' \
     --ServerApp.allow_origin='*'
 else
-  jupyter lab --ip 0.0.0.0 --port 8888 \
+  exec jupyter lab --ip 0.0.0.0 --port 8888 \
     --ServerApp.token='' \
     --ServerApp.allow_origin='*'
 fi

--- a/template/v4/v4.1/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.1/dirs/usr/local/bin/start-jupyter-server
@@ -55,7 +55,7 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   # SAGEMAKER_SPACE_TYPE_LOWERCASE flag is used to determine if the server should start
   # in real-time-collaboration mode for a given space.
-  jupyter lab --ip 0.0.0.0 --port 8888 \
+  exec jupyter lab --ip 0.0.0.0 --port 8888 \
     --ServerApp.base_url="/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
     --ServerApp.token='' \
     --ServerApp.allow_origin='*' \
@@ -67,12 +67,12 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
-  jupyter lab --ip 0.0.0.0 --port 8888 \
+  exec jupyter lab --ip 0.0.0.0 --port 8888 \
     --ServerApp.base_url="/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
     --ServerApp.token='' \
     --ServerApp.allow_origin='*'
 else
-  jupyter lab --ip 0.0.0.0 --port 8888 \
+  exec jupyter lab --ip 0.0.0.0 --port 8888 \
     --ServerApp.token='' \
     --ServerApp.allow_origin='*'
 fi

--- a/template/v4/v4.2/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.2/dirs/usr/local/bin/start-jupyter-server
@@ -55,7 +55,7 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   # SAGEMAKER_SPACE_TYPE_LOWERCASE flag is used to determine if the server should start
   # in real-time-collaboration mode for a given space.
-  jupyter lab --ip 0.0.0.0 --port 8888 \
+  exec jupyter lab --ip 0.0.0.0 --port 8888 \
     --ServerApp.base_url="/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
     --ServerApp.token='' \
     --ServerApp.allow_origin='*' \
@@ -67,12 +67,12 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
-  jupyter lab --ip 0.0.0.0 --port 8888 \
+  exec jupyter lab --ip 0.0.0.0 --port 8888 \
     --ServerApp.base_url="/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
     --ServerApp.token='' \
     --ServerApp.allow_origin='*'
 else
-  jupyter lab --ip 0.0.0.0 --port 8888 \
+  exec jupyter lab --ip 0.0.0.0 --port 8888 \
     --ServerApp.token='' \
     --ServerApp.allow_origin='*'
 fi

--- a/template/v4/v4.3/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.3/dirs/usr/local/bin/start-jupyter-server
@@ -55,7 +55,7 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   # SAGEMAKER_SPACE_TYPE_LOWERCASE flag is used to determine if the server should start
   # in real-time-collaboration mode for a given space.
-  jupyter lab --ip 0.0.0.0 --port 8888 \
+  exec jupyter lab --ip 0.0.0.0 --port 8888 \
     --ServerApp.base_url="/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
     --ServerApp.token='' \
     --ServerApp.allow_origin='*' \
@@ -67,12 +67,12 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
-  jupyter lab --ip 0.0.0.0 --port 8888 \
+  exec jupyter lab --ip 0.0.0.0 --port 8888 \
     --ServerApp.base_url="/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
     --ServerApp.token='' \
     --ServerApp.allow_origin='*'
 else
-  jupyter lab --ip 0.0.0.0 --port 8888 \
+  exec jupyter lab --ip 0.0.0.0 --port 8888 \
     --ServerApp.token='' \
     --ServerApp.allow_origin='*'
 fi

--- a/template/v4/v4.4/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.4/dirs/usr/local/bin/start-jupyter-server
@@ -55,7 +55,7 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   # SAGEMAKER_SPACE_TYPE_LOWERCASE flag is used to determine if the server should start
   # in real-time-collaboration mode for a given space.
-  jupyter lab --ip 0.0.0.0 --port 8888 \
+  exec jupyter lab --ip 0.0.0.0 --port 8888 \
     --ServerApp.base_url="/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
     --ServerApp.token='' \
     --ServerApp.allow_origin='*' \
@@ -67,12 +67,12 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
-  jupyter lab --ip 0.0.0.0 --port 8888 \
+  exec jupyter lab --ip 0.0.0.0 --port 8888 \
     --ServerApp.base_url="/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
     --ServerApp.token='' \
     --ServerApp.allow_origin='*'
 else
-  jupyter lab --ip 0.0.0.0 --port 8888 \
+  exec jupyter lab --ip 0.0.0.0 --port 8888 \
     --ServerApp.token='' \
     --ServerApp.allow_origin='*'
 fi


### PR DESCRIPTION
## Description
When supervisord sends SIGTERM with stopasgroup=true, the bash wrapper receives the signal and exits immediately (no trap handler). Supervisord sees its tracked process (bash) die and reports the program stopped, while jupyter-lab is left orphaned mid-cleanup and killed before it can complete saving open documents -- resulting in 0-byte notebook files.

Adding exec replaces the bash process with jupyter-lab so supervisord tracks the correct PID and gives it the full grace period for shutdown.

Confirmed: without exec = 31ms truncated shutdown (data loss), with exec = 3.3s graceful shutdown (all YRooms saved, kernels shut down, exit status 0).

## Type of Change
- [x] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [x] Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
Potential of data loss

## How Has This Been Tested?
- Update SMAI to use new supervisor and ran multiple stop / start cycles

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

## Related Issues
[Link any related issues here]

## Additional Notes
[Any additional information that might be helpful for reviewers]
