### PR TITLE
fix: Disable Amazon Q gen-AI extension in SMAI via config and rm

### DIFF
--- a/template/v4/v4.4/dirs/etc/sagemaker/jupyter/server/jupyter_server_config.d/zzz_sagemaker_overrides.json
+++ b/template/v4/v4.4/dirs/etc/sagemaker/jupyter/server/jupyter_server_config.d/zzz_sagemaker_overrides.json
@@ -3,7 +3,8 @@
     "jpserver_extensions": {
       "sagemaker_studio_jupyter_scheduler": false,
       "sagemaker_jupyter_server_extension": false,
-      "panel.io.jupyter_server_extension": false
+      "panel.io.jupyter_server_extension": false,
+      "sagemaker_gen_ai_jupyterlab_extension": false
     }
   }
 }

--- a/template/v4/v4.4/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.4/dirs/usr/local/bin/start-jupyter-server
@@ -11,12 +11,6 @@ else
     # Activate conda environment 'base'
     micromamba activate base
 
-    # Disable the Amazon Q gen-AI JupyterLab experience
-    # Server-ext disable stops _load_jupyter_server_extension -> initialize_lsp_server()
-    jupyter server extension disable sagemaker_gen_ai_jupyterlab_extension
-    # Labext disable removes the chat panel from the sidebar
-    jupyter labextension disable @amzn/sagemaker_gen_ai_jupyterlab_extension
-
     # Disable SMUS server extensions
     cp /etc/sagemaker/jupyter/server/jupyter_server_config.d/zzz_sagemaker_overrides.json /opt/conda/etc/jupyter/jupyter_server_config.d/
 
@@ -29,6 +23,9 @@ else
         /opt/conda/share/jupyter/labextensions/sagemaker_sparkmonitor/package.json \
         /opt/conda/share/jupyter/labextensions/@pyviz/jupyterlab_pyviz/package.json \
         /opt/conda/share/jupyter/labextensions/@amzn/sagemaker_post_startup_notification_plugin/package.json
+
+    # Disable the Amazon Q gen-AI lab extension (chat panel) in SMAI
+    rm -f /opt/conda/share/jupyter/labextensions/@amzn/sagemaker_gen_ai_jupyterlab_extension/package.json
 fi
 
 # Setup skills and subagent for SMAI private spaces only


### PR DESCRIPTION
## Description
Disable the Amazon Q gen-AI JupyterLab extension in SMAI
1. **Server extension**: Added `sagemaker_gen_ai_jupyterlab_extension: false` to `zzz_sagemaker_overrides.json` prevents `_load_jupyter_server_extension` → `initialize_lsp_server()` from running, reclaiming memory.
2. **Lab extension**: Added `rm -f` of `@amzn/sagemaker_gen_ai_jupyterlab_extension/package.json` — removes the chat panel from the sidebar
3. Both are file/fs ops at startup with ~0 added boot time. SMUS entrypoint is untouched.

## Type of Change
- [ ] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ ] Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]

## How Has This Been Tested?
[Describe the tests you ran]

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
[Link any related issues here]

## Additional Notes
[Any additional information that might be helpful for reviewers]
