### PR TITLE
Remove rtc disable from dockerfile v4.5

### DIFF
--- a/template/v4/v4.5/Dockerfile
+++ b/template/v4/v4.5/Dockerfile
@@ -221,11 +221,7 @@ RUN if [[ -z $ARG_BASED_ENV_IN_FILENAME ]] ; \
     cp -a ${SYSTEM_PYTHON_PATH}/sagemaker_studio_analytics_extension/patches/reliablehttpclient.py ${SYSTEM_PYTHON_PATH}/sparkmagic/livyclientlib/reliablehttpclient.py && \
     sed -i 's=  "python"=  "/opt/conda/bin/python"=g'  /opt/conda/share/jupyter/kernels/pysparkkernel/kernel.json /opt/conda/share/jupyter/kernels/sparkkernel/kernel.json && \
     sed -i 's="Spark"="SparkMagic Spark"=g'  /opt/conda/share/jupyter/kernels/sparkkernel/kernel.json && \
-    sed -i 's="PySpark"="SparkMagic PySpark"=g'  /opt/conda/share/jupyter/kernels/pysparkkernel/kernel.json && \
-    # Configure RTC - disable jupyter_collaboration by default
-    jupyter labextension disable @jupyter/collaboration-extension && \
-    # Disable docprovider-extension for v3 and above images
-    jupyter labextension disable @jupyter/docprovider-extension
+    sed -i 's="PySpark"="SparkMagic PySpark"=g'  /opt/conda/share/jupyter/kernels/pysparkkernel/kernel.json
 
 
 # Patch glue kernels to use kernel wrapper

--- a/template/v4/v4.5/dirs/usr/local/bin/start-sagemaker-ui-jupyter-server
+++ b/template/v4/v4.5/dirs/usr/local/bin/start-sagemaker-ui-jupyter-server
@@ -12,8 +12,6 @@ else
     micromamba activate base
     micromamba remove -y jupyter_server_documents
 
-    # Enable RTC to allow async Q file updates
-    jupyter labextension enable @jupyter/docprovider-extension
     jupyter server extension enable jupyter_server_ydoc
 fi
 


### PR DESCRIPTION
## Description
Remove RTC labextension disable statements from v4.5 Dockerfile
    
Delete the two `jupyter labextension disable` statements from the v4.5 Dockerfile that baked a "disabled by default" state for the RTC extensions into the base image:
```
jupyter labextension disable @jupyter/collaboration-extension
jupyter labextension disable @jupyter/docprovider-extension
```

These statements are redundant: both consuming products already fully manage these extensions' state at runtime in their own start scripts, so the baked base-image default is never the effective state.
    
    - SMAI (start-jupyter-server): explicitly re-enables both extensions
      (`jupyter labextension enable @jupyter/collaboration-extension` and
      `@jupyter/docprovider-extension`). Its lab settings tree
      (/etc/sagemaker/jupyter/lab/settings) ships only overrides.json and no
      page_config.json, so it never touches the disabled map beyond those
      explicit enable calls. Net state: both enabled -- unchanged by this commit.
    
    - SMUS (start-sagemaker-ui-jupyter-server): copies its own page_config.json
      (/etc/sagemaker-ui/jupyter/lab/settings) over the base image's, in which
      @jupyter/collaboration-extension is disabled and docprovider is not, and
      additionally enables docprovider at runtime. Net state: collaboration
      disabled, docprovider enabled -- unchanged by this commit.
    
The only difference is the base-image default flips from "disabled" to JupyterLab's normal "enabled", which is observable only if jupyter lab is launched without going through either start script -- not how the distribution runs. Extension state is now owned explicitly by each product rather than split between a base-image default and per-product overrides.

## Type of Change
- [ ] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ ] Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]

## How Has This Been Tested?
Will have it merged and test 4.5.0 nightly build image

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
[Link any related issues here]

## Additional Notes
[Any additional information that might be helpful for reviewers]
