### PR TITLE
fix: backport exec fix to start-jupyter-server for v2.14 and v3.9 - u…

### DIFF
--- a/template/v2/v2.14/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v2/v2.14/dirs/usr/local/bin/start-jupyter-server
@@ -32,7 +32,7 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   # SAGEMAKER_SPACE_TYPE_LOWERCASE flag is used to determine if the server should start
   # in real-time-collaboration mode for a given space.
-  jupyter lab --ip 0.0.0.0 --port 8888 \
+  exec jupyter lab --ip 0.0.0.0 --port 8888 \
     --ServerApp.base_url="/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
     --ServerApp.token='' \
     --ServerApp.allow_origin='*' \
@@ -44,12 +44,12 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
-  jupyter lab --ip 0.0.0.0 --port 8888 \
+  exec jupyter lab --ip 0.0.0.0 --port 8888 \
     --ServerApp.base_url="/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
     --ServerApp.token='' \
     --ServerApp.allow_origin='*'
 else
-  jupyter lab --ip 0.0.0.0 --port 8888 \
+  exec jupyter lab --ip 0.0.0.0 --port 8888 \
     --ServerApp.token='' \
     --ServerApp.allow_origin='*'
 fi

--- a/template/v3/v3.9/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v3/v3.9/dirs/usr/local/bin/start-jupyter-server
@@ -30,7 +30,7 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   # SAGEMAKER_SPACE_TYPE_LOWERCASE flag is used to determine if the server should start
   # in real-time-collaboration mode for a given space.
-  jupyter lab --ip 0.0.0.0 --port 8888 \
+  exec jupyter lab --ip 0.0.0.0 --port 8888 \
     --ServerApp.base_url="/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
     --ServerApp.token='' \
     --ServerApp.allow_origin='*' \
@@ -42,12 +42,12 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
-  jupyter lab --ip 0.0.0.0 --port 8888 \
+  exec jupyter lab --ip 0.0.0.0 --port 8888 \
     --ServerApp.base_url="/$SAGEMAKER_APP_TYPE_LOWERCASE/default" \
     --ServerApp.token='' \
     --ServerApp.allow_origin='*'
 else
-  jupyter lab --ip 0.0.0.0 --port 8888 \
+  exec jupyter lab --ip 0.0.0.0 --port 8888 \
     --ServerApp.token='' \
     --ServerApp.allow_origin='*'
 fi


### PR DESCRIPTION
…se exec for jupyter lab to enable graceful shutdown

## Description
Same fix as https://github.com/aws/sagemaker-distribution/pull/1290 but for supported 2.X and 3.X SMD Versions
 
## Type of Change
- [X] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
-  [X] Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]
Potential of data loss



## How Has This Been Tested?
Update SMAI to use new supervisor and ran multiple stop / start cycles

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
[Link any related issues here]

## Additional Notes
[Any additional information that might be helpful for reviewers]
