### PR TITLE
fix: disable RTC and Jupyter AI for v4.1-v4.4 private/shared spaces

### DIFF
--- a/template/v4/v4.1/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.1/dirs/usr/local/bin/start-jupyter-server
@@ -48,7 +48,11 @@ fi
 
 # Start Jupyter server in rtc mode for shared spaces (skip in recovery mode)
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ] && [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
+  # Remove JSD and Jupyter AI, then re-enable native Jupyter Collaboration
+  micromamba remove -y jupyter-ai jupyter_server_documents jupyterlab-chat
   jupyter labextension enable @jupyter/collaboration-extension
+  jupyter labextension enable @jupyter/docprovider-extension
+  jupyter server extension enable jupyter_server_ydoc
   # Disable chat icon in shared spaces
   jupyter labextension disable jupyterlab-chat-extension
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
@@ -65,6 +69,9 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 
 # Start Jupyter server
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
+  if [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
+    micromamba remove -y jupyter-ai jupyter_server_documents jupyter-collaboration jupyterlab-chat
+  fi
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   exec jupyter lab --ip 0.0.0.0 --port 8888 \

--- a/template/v4/v4.2/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.2/dirs/usr/local/bin/start-jupyter-server
@@ -48,7 +48,11 @@ fi
 
 # Start Jupyter server in rtc mode for shared spaces (skip in recovery mode)
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ] && [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
+  # Remove JSD and Jupyter AI, then re-enable native Jupyter Collaboration
+  micromamba remove -y jupyter-ai jupyter_server_documents jupyterlab-chat
   jupyter labextension enable @jupyter/collaboration-extension
+  jupyter labextension enable @jupyter/docprovider-extension
+  jupyter server extension enable jupyter_server_ydoc
   # Disable chat icon in shared spaces
   jupyter labextension disable jupyterlab-chat-extension
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
@@ -65,6 +69,9 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 
 # Start Jupyter server
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
+  if [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
+    micromamba remove -y jupyter-ai jupyter_server_documents jupyter-collaboration jupyterlab-chat
+  fi
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   exec jupyter lab --ip 0.0.0.0 --port 8888 \

--- a/template/v4/v4.3/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.3/dirs/usr/local/bin/start-jupyter-server
@@ -48,7 +48,11 @@ fi
 
 # Start Jupyter server in rtc mode for shared spaces (skip in recovery mode)
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ] && [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
+  # Remove JSD and Jupyter AI, then re-enable native Jupyter Collaboration
+  micromamba remove -y jupyter-ai jupyter_server_documents jupyterlab-chat
   jupyter labextension enable @jupyter/collaboration-extension
+  jupyter labextension enable @jupyter/docprovider-extension
+  jupyter server extension enable jupyter_server_ydoc
   # Disable chat icon in shared spaces
   jupyter labextension disable jupyterlab-chat-extension
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
@@ -65,6 +69,9 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 
 # Start Jupyter server
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
+  if [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
+    micromamba remove -y jupyter-ai jupyter_server_documents jupyter-collaboration jupyterlab-chat
+  fi
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   exec jupyter lab --ip 0.0.0.0 --port 8888 \

--- a/template/v4/v4.4/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.4/dirs/usr/local/bin/start-jupyter-server
@@ -50,11 +50,14 @@ if [ -n "$TRUSTED_IDENTITY_PROPOGATION_ENABLED" ]; then
     echo BOTOCORE_EXPERIMENTAL__PLUGINS=S3AccessGrantsPlugin=aws_s3_access_grants_boto3_plugin.s3_access_grants_plugin >> ~/.bashrc
 fi
 
-jupyter labextension enable @jupyter/collaboration-extension
-jupyter labextension enable @jupyter/docprovider-extension
-
 # Start Jupyter server in rtc mode for shared spaces (skip in recovery mode)
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ] && [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
+  # Remove JSD and Jupyter AI, then re-enable native Jupyter Collaboration
+  micromamba remove -y jupyter-ai jupyter_server_documents jupyterlab-chat
+  # Enable real-time collaboration extensions for shared spaces only
+  jupyter labextension enable @jupyter/collaboration-extension
+  jupyter labextension enable @jupyter/docprovider-extension
+  jupyter server extension enable jupyter_server_ydoc
   # Disable chat icon in shared spaces
   jupyter labextension disable jupyterlab-chat-extension
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
@@ -71,6 +74,9 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 
 # Start Jupyter server
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
+  if [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
+    micromamba remove -y jupyter-ai jupyter_server_documents jupyter-collaboration jupyterlab-chat
+  fi
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   exec jupyter lab --ip 0.0.0.0 --port 8888 \


### PR DESCRIPTION
Private spaces: remove jupyter-ai, jupyter_server_documents, jupyter-collaboration, and jupyterlab-chat to fully disable RTC, the source of the notebook truncation data loss. Guarded to skip recovery mode.

Shared spaces: remove jupyter-ai, jupyter_server_documents, and jupyterlab-chat, but retain jupyter-collaboration and re-enable native Jupyter Collaboration (enable @jupyter/collaboration-extension, @jupyter/docprovider-extension, and the jupyter_server_ydoc server extension).

## Description
[Provide a brief description of the changes]

## Type of Change
- [ ] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [ ] Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]

## How Has This Been Tested?
[Describe the tests you ran]

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
[Link any related issues here]

## Additional Notes
[Any additional information that might be helpful for reviewers]
