### PR TITLE
fix(post-startup): Add git credential helper and identity for new Git v2 projects

### DIFF
--- a/template/v2/v2.14/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/template/v2/v2.14/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -159,6 +159,14 @@ case "$auth_mode" in
         # Split ARN by / and return the last field
         username=$(echo "$arn" | awk -F'/' '{print $NF}')
         email="$arn"
+        # For git identity, use session name if available (matches Git Compute image behavior)
+        session_name=$(echo "$response" | jq -r '.details.iam.sessionName // empty')
+        if [ -n "$session_name" ]; then
+            git_username="$session_name"
+        else
+            git_username="$username"
+        fi
+        git_email="$git_username"
         ;;
     "SSO"|"SAML")
         # For SSO and SAML user, extract username and email if present in response.
@@ -168,6 +176,8 @@ case "$auth_mode" in
         if [ -z "$email" ] || [ "$email" = "null" ]; then
             email="$username"
         fi
+        git_username="$username"
+        git_email="$email"
         ;;
     *)
         echo "Unknown authentication mode: $auth_mode"
@@ -228,9 +238,9 @@ if [ $is_s3_storage_flag -ne 0 ]; then
   echo "Starting execution of Git Cloning script"
   bash /etc/sagemaker-ui/git_clone.sh
 
-  # Setting up the Git identity for the user .
-  git config --global user.email "$email"
-  git config --global user.name "$username"
+  # Setting up the Git identity for the user.
+  git config --global user.email "$git_email"
+  git config --global user.name "$git_username"
   if [ -d "$HOME/shared" ]; then
     echo "Git project with /shared folder detected, creating README"
     bash /etc/sagemaker-ui/project-storage/create-storage-readme.sh
@@ -238,6 +248,12 @@ if [ $is_s3_storage_flag -ne 0 ]; then
     echo "Git project without /shared folder, skipping README creation"
   fi
 else
+  # New Git v2 / S3 project: configure credential helper and identity so that
+  # git push/pull works for repos cloned by the SMUS Git backend into ~/shared/repos/.
+  git config --global user.email "$git_email"
+  git config --global user.name "$git_username"
+  git config --global credential.helper "!aws codecommit credential-helper --ignore-host-check \$@"
+  git config --global credential.UseHttpPath true
   echo "Project is using Non-Git storage, skipping git repository setup and ~/src dir creation and creating README"
   bash /etc/sagemaker-ui/project-storage/create-storage-readme.sh
 fi

--- a/template/v3/v3.9/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/template/v3/v3.9/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -160,6 +160,14 @@ case "$auth_mode" in
         # Split ARN by / and return the last field
         username=$(echo "$arn" | awk -F'/' '{print $NF}')
         email="$arn"
+        # For git identity, use session name if available (matches Git Compute image behavior)
+        session_name=$(echo "$response" | jq -r '.details.iam.sessionName // empty')
+        if [ -n "$session_name" ]; then
+            git_username="$session_name"
+        else
+            git_username="$username"
+        fi
+        git_email="$git_username"
         ;;
     "SSO"|"SAML")
         # For SSO and SAML user, extract username and email if present in response.
@@ -169,6 +177,8 @@ case "$auth_mode" in
         if [ -z "$email" ] || [ "$email" = "null" ]; then
             email="$username"
         fi
+        git_username="$username"
+        git_email="$email"
         ;;
     *)
         echo "Unknown authentication mode: $auth_mode"
@@ -229,9 +239,9 @@ if [ $is_s3_storage_flag -ne 0 ]; then
   echo "Starting execution of Git Cloning script"
   bash /etc/sagemaker-ui/git_clone.sh
 
-  # Setting up the Git identity for the user .
-  git config --global user.email "$email"
-  git config --global user.name "$username"
+  # Setting up the Git identity for the user.
+  git config --global user.email "$git_email"
+  git config --global user.name "$git_username"
   if [ -d "$HOME/shared" ]; then
     echo "Git project with /shared folder detected, creating README"
     bash /etc/sagemaker-ui/project-storage/create-storage-readme.sh
@@ -239,6 +249,12 @@ if [ $is_s3_storage_flag -ne 0 ]; then
     echo "Git project without /shared folder, skipping README creation"
   fi
 else
+  # New Git v2 / S3 project: configure credential helper and identity so that
+  # git push/pull works for repos cloned by the SMUS Git backend into ~/shared/repos/.
+  git config --global user.email "$git_email"
+  git config --global user.name "$git_username"
+  git config --global credential.helper "!aws codecommit credential-helper --ignore-host-check \$@"
+  git config --global credential.UseHttpPath true
   echo "Project is using Non-Git storage, skipping git repository setup and ~/src dir creation and creating README"
   bash /etc/sagemaker-ui/project-storage/create-storage-readme.sh
 fi

--- a/template/v4/v4.0/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/template/v4/v4.0/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -160,6 +160,14 @@ case "$auth_mode" in
         # Split ARN by / and return the last field
         username=$(echo "$arn" | awk -F'/' '{print $NF}')
         email="$arn"
+        # For git identity, use session name if available (matches Git Compute image behavior)
+        session_name=$(echo "$response" | jq -r '.details.iam.sessionName // empty')
+        if [ -n "$session_name" ]; then
+            git_username="$session_name"
+        else
+            git_username="$username"
+        fi
+        git_email="$git_username"
         ;;
     "SSO"|"SAML")
         # For SSO and SAML user, extract username and email if present in response.
@@ -169,6 +177,8 @@ case "$auth_mode" in
         if [ -z "$email" ] || [ "$email" = "null" ]; then
             email="$username"
         fi
+        git_username="$username"
+        git_email="$email"
         ;;
     *)
         echo "Unknown authentication mode: $auth_mode"
@@ -229,9 +239,9 @@ if [ $is_s3_storage_flag -ne 0 ]; then
   echo "Starting execution of Git Cloning script"
   bash /etc/sagemaker-ui/git_clone.sh
 
-  # Setting up the Git identity for the user .
-  git config --global user.email "$email"
-  git config --global user.name "$username"
+  # Setting up the Git identity for the user.
+  git config --global user.email "$git_email"
+  git config --global user.name "$git_username"
   if [ -d "$HOME/shared" ]; then
     echo "Git project with /shared folder detected, creating README"
     bash /etc/sagemaker-ui/project-storage/create-storage-readme.sh
@@ -239,6 +249,12 @@ if [ $is_s3_storage_flag -ne 0 ]; then
     echo "Git project without /shared folder, skipping README creation"
   fi
 else
+  # New Git v2 / S3 project: configure credential helper and identity so that
+  # git push/pull works for repos cloned by the SMUS Git backend into ~/shared/repos/.
+  git config --global user.email "$git_email"
+  git config --global user.name "$git_username"
+  git config --global credential.helper "!aws codecommit credential-helper --ignore-host-check \$@"
+  git config --global credential.UseHttpPath true
   echo "Project is using Non-Git storage, skipping git repository setup and ~/src dir creation and creating README"
   bash /etc/sagemaker-ui/project-storage/create-storage-readme.sh
 fi

--- a/template/v4/v4.1/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/template/v4/v4.1/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -160,6 +160,14 @@ case "$auth_mode" in
         # Split ARN by / and return the last field
         username=$(echo "$arn" | awk -F'/' '{print $NF}')
         email="$arn"
+        # For git identity, use session name if available (matches Git Compute image behavior)
+        session_name=$(echo "$response" | jq -r '.details.iam.sessionName // empty')
+        if [ -n "$session_name" ]; then
+            git_username="$session_name"
+        else
+            git_username="$username"
+        fi
+        git_email="$git_username"
         ;;
     "SSO"|"SAML")
         # For SSO and SAML user, extract username and email if present in response.
@@ -169,6 +177,8 @@ case "$auth_mode" in
         if [ -z "$email" ] || [ "$email" = "null" ]; then
             email="$username"
         fi
+        git_username="$username"
+        git_email="$email"
         ;;
     *)
         echo "Unknown authentication mode: $auth_mode"
@@ -229,9 +239,9 @@ if [ $is_s3_storage_flag -ne 0 ]; then
   echo "Starting execution of Git Cloning script"
   bash /etc/sagemaker-ui/git_clone.sh
 
-  # Setting up the Git identity for the user .
-  git config --global user.email "$email"
-  git config --global user.name "$username"
+  # Setting up the Git identity for the user.
+  git config --global user.email "$git_email"
+  git config --global user.name "$git_username"
   if [ -d "$HOME/shared" ]; then
     echo "Git project with /shared folder detected, creating README"
     bash /etc/sagemaker-ui/project-storage/create-storage-readme.sh
@@ -239,6 +249,12 @@ if [ $is_s3_storage_flag -ne 0 ]; then
     echo "Git project without /shared folder, skipping README creation"
   fi
 else
+  # New Git v2 / S3 project: configure credential helper and identity so that
+  # git push/pull works for repos cloned by the SMUS Git backend into ~/shared/repos/.
+  git config --global user.email "$git_email"
+  git config --global user.name "$git_username"
+  git config --global credential.helper "!aws codecommit credential-helper --ignore-host-check \$@"
+  git config --global credential.UseHttpPath true
   echo "Project is using Non-Git storage, skipping git repository setup and ~/src dir creation and creating README"
   bash /etc/sagemaker-ui/project-storage/create-storage-readme.sh
 fi

--- a/template/v4/v4.2/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/template/v4/v4.2/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -160,6 +160,14 @@ case "$auth_mode" in
         # Split ARN by / and return the last field
         username=$(echo "$arn" | awk -F'/' '{print $NF}')
         email="$arn"
+        # For git identity, use session name if available (matches Git Compute image behavior)
+        session_name=$(echo "$response" | jq -r '.details.iam.sessionName // empty')
+        if [ -n "$session_name" ]; then
+            git_username="$session_name"
+        else
+            git_username="$username"
+        fi
+        git_email="$git_username"
         ;;
     "SSO"|"SAML")
         # For SSO and SAML user, extract username and email if present in response.
@@ -169,6 +177,8 @@ case "$auth_mode" in
         if [ -z "$email" ] || [ "$email" = "null" ]; then
             email="$username"
         fi
+        git_username="$username"
+        git_email="$email"
         ;;
     *)
         echo "Unknown authentication mode: $auth_mode"
@@ -229,9 +239,9 @@ if [ $is_s3_storage_flag -ne 0 ]; then
   echo "Starting execution of Git Cloning script"
   bash /etc/sagemaker-ui/git_clone.sh
 
-  # Setting up the Git identity for the user .
-  git config --global user.email "$email"
-  git config --global user.name "$username"
+  # Setting up the Git identity for the user.
+  git config --global user.email "$git_email"
+  git config --global user.name "$git_username"
   if [ -d "$HOME/shared" ]; then
     echo "Git project with /shared folder detected, creating README"
     bash /etc/sagemaker-ui/project-storage/create-storage-readme.sh
@@ -239,6 +249,12 @@ if [ $is_s3_storage_flag -ne 0 ]; then
     echo "Git project without /shared folder, skipping README creation"
   fi
 else
+  # New Git v2 / S3 project: configure credential helper and identity so that
+  # git push/pull works for repos cloned by the SMUS Git backend into ~/shared/repos/.
+  git config --global user.email "$git_email"
+  git config --global user.name "$git_username"
+  git config --global credential.helper "!aws codecommit credential-helper --ignore-host-check \$@"
+  git config --global credential.UseHttpPath true
   echo "Project is using Non-Git storage, skipping git repository setup and ~/src dir creation and creating README"
   bash /etc/sagemaker-ui/project-storage/create-storage-readme.sh
 fi

--- a/template/v4/v4.3/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/template/v4/v4.3/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -160,6 +160,14 @@ case "$auth_mode" in
         # Split ARN by / and return the last field
         username=$(echo "$arn" | awk -F'/' '{print $NF}')
         email="$arn"
+        # For git identity, use session name if available (matches Git Compute image behavior)
+        session_name=$(echo "$response" | jq -r '.details.iam.sessionName // empty')
+        if [ -n "$session_name" ]; then
+            git_username="$session_name"
+        else
+            git_username="$username"
+        fi
+        git_email="$git_username"
         ;;
     "SSO"|"SAML")
         # For SSO and SAML user, extract username and email if present in response.
@@ -169,6 +177,8 @@ case "$auth_mode" in
         if [ -z "$email" ] || [ "$email" = "null" ]; then
             email="$username"
         fi
+        git_username="$username"
+        git_email="$email"
         ;;
     *)
         echo "Unknown authentication mode: $auth_mode"
@@ -229,9 +239,9 @@ if [ $is_s3_storage_flag -ne 0 ]; then
   echo "Starting execution of Git Cloning script"
   bash /etc/sagemaker-ui/git_clone.sh
 
-  # Setting up the Git identity for the user .
-  git config --global user.email "$email"
-  git config --global user.name "$username"
+  # Setting up the Git identity for the user.
+  git config --global user.email "$git_email"
+  git config --global user.name "$git_username"
   if [ -d "$HOME/shared" ]; then
     echo "Git project with /shared folder detected, creating README"
     bash /etc/sagemaker-ui/project-storage/create-storage-readme.sh
@@ -239,6 +249,12 @@ if [ $is_s3_storage_flag -ne 0 ]; then
     echo "Git project without /shared folder, skipping README creation"
   fi
 else
+  # New Git v2 / S3 project: configure credential helper and identity so that
+  # git push/pull works for repos cloned by the SMUS Git backend into ~/shared/repos/.
+  git config --global user.email "$git_email"
+  git config --global user.name "$git_username"
+  git config --global credential.helper "!aws codecommit credential-helper --ignore-host-check \$@"
+  git config --global credential.UseHttpPath true
   echo "Project is using Non-Git storage, skipping git repository setup and ~/src dir creation and creating README"
   bash /etc/sagemaker-ui/project-storage/create-storage-readme.sh
 fi

--- a/template/v4/v4.4/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
+++ b/template/v4/v4.4/dirs/etc/sagemaker-ui/sagemaker_ui_post_startup.sh
@@ -160,6 +160,14 @@ case "$auth_mode" in
         # Split ARN by / and return the last field
         username=$(echo "$arn" | awk -F'/' '{print $NF}')
         email="$arn"
+        # For git identity, use session name if available (matches Git Compute image behavior)
+        session_name=$(echo "$response" | jq -r '.details.iam.sessionName // empty')
+        if [ -n "$session_name" ]; then
+            git_username="$session_name"
+        else
+            git_username="$username"
+        fi
+        git_email="$git_username"
         ;;
     "SSO"|"SAML")
         # For SSO and SAML user, extract username and email if present in response.
@@ -169,6 +177,8 @@ case "$auth_mode" in
         if [ -z "$email" ] || [ "$email" = "null" ]; then
             email="$username"
         fi
+        git_username="$username"
+        git_email="$email"
         ;;
     *)
         echo "Unknown authentication mode: $auth_mode"
@@ -229,9 +239,9 @@ if [ $is_s3_storage_flag -ne 0 ]; then
   echo "Starting execution of Git Cloning script"
   bash /etc/sagemaker-ui/git_clone.sh
 
-  # Setting up the Git identity for the user .
-  git config --global user.email "$email"
-  git config --global user.name "$username"
+  # Setting up the Git identity for the user.
+  git config --global user.email "$git_email"
+  git config --global user.name "$git_username"
   if [ -d "$HOME/shared" ]; then
     echo "Git project with /shared folder detected, creating README"
     bash /etc/sagemaker-ui/project-storage/create-storage-readme.sh
@@ -239,6 +249,12 @@ if [ $is_s3_storage_flag -ne 0 ]; then
     echo "Git project without /shared folder, skipping README creation"
   fi
 else
+  # New Git v2 / S3 project: configure credential helper and identity so that
+  # git push/pull works for repos cloned by the SMUS Git backend into ~/shared/repos/.
+  git config --global user.email "$git_email"
+  git config --global user.name "$git_username"
+  git config --global credential.helper "!aws codecommit credential-helper --ignore-host-check \$@"
+  git config --global credential.UseHttpPath true
   echo "Project is using Non-Git storage, skipping git repository setup and ~/src dir creation and creating README"
   bash /etc/sagemaker-ui/project-storage/create-storage-readme.sh
 fi


### PR DESCRIPTION
## Description
New Git v2 projects have no git credential helper or identity configured during space startup. This causes `git commit` and `git push` to fail from the terminal for repos cloned by the user through the portal into `~/shared` folder.

This change adds git credential helper and identity setup in the sagemaker_ui_post_startup.sh so that new Git v2 projects work out of the box. The git v1 path remains completely untouched.

## Type of Change
- [X] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [X] Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
Users on new Git v2 projects cannot push or pull from the terminal without manually configuring the credential helper. We have customer escalations from visa.
Related Ticket: https://t.corp.amazon.com/P495689715/overview

## How Has This Been Tested?
Yes, Tested with custom BYOI image containing the fix.

Existing Git v1 Project 
* DomainExecutionRoleCreds configured successfully
* is_s3_storage_flag = 1 (correctly identified as legacy git)
* git_clone.sh ran
* git_config.sh ran (sets credential helper with --profile DomainExecutionRoleCreds)
* Final credential helper:!aws --profile DomainExecutionRoleCreds --region us-west-2 codecommit credential-helper --ignore-host-check
* Git identity set: user.email=athkulk, user.name=athkulk

Migarted Project: SSO and IAM
* DomainExecutionRoleCreds configured successfully
* is_s3_storage_flag = 1 (correctly identified as legacy/migrated git)
* git_clone.sh ran
* git_config.sh ran (sets credential helper with --profile DomainExecutionRoleCreds)
* Final credential helper:!aws --profile DomainExecutionRoleCreds --region us-west-2 codecommit credential-helper --ignore-host-check
* Git identity set: 
SSO: user.email=athkulk, user.name=athkulk
IAM: user.email=athkulk-Isengard, user.name=athkulk-Isengard
* git push succeeded (to CodeConnections URL)
* git pull succeeded

New project using existing git project profile
* DomainExecutionRoleCreds configured successfully
* is_s3_storage_flag = 1 (git project profile → has gitConnectionArn)
* git_clone.sh ran
* git_config.sh ran (sets credential helper with --profile DomainExecutionRoleCreds)
* Final credential helper:!aws --profile DomainExecutionRoleCreds --region us-west-2 codecommit credential-helper --ignore-host-check
* Git identity set: user.email=athkulk, user.name=athkulk
* git push succeeded (to ~/src repo)
* git pull succeeded

S3 based project (New Git V2 Experience)
* is_s3_storage_flag = 0 (correctly identified as new Git v2)
* git_clone.sh did NOT run (correct -- not a legacy project)git_config.sh did NOT run (correct -- not called)
* Credential helper set:!aws codecommit credential-helper --ignore-host-check $@(no --profile, uses project role)
* Git identity set: user.email=athkulk-Isengard, user.name=athkulk-Isengard
* git push succeeded
* git pull succeeded

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works

## Related Issues
Related Ticket: https://t.corp.amazon.com/P495689715/overview

## Additional Notes
Only made changes in post-startup script in the template folder for all supported SMD image versions documented in https://github.com/aws/sagemaker-distribution/blob/main/support_policy.md
