### PR TITLE
Add a `just update-outfiles` helper script

### DIFF
--- a/environment.lock
+++ b/environment.lock
@@ -88,6 +88,7 @@ https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhd8ed1ab_0.conda#44
 https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda#972bdca8f30147135f951847b30399ea
 https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_1.conda#cb60ae9cf02b9fcb8004dec4089e5691
 https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py313h78bf25f_1.conda#668d64b50e7ce7984cfe09ed7045b9fa
+https://conda.anaconda.org/conda-forge/linux-64/just-1.58.0-hf19af3b_2.conda#71b9f34fa13ed62c43c7ced16ed93914
 https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2#30186d27e2c9fa62b45fb1476b7200e3
 https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda#3f43953b7d3fb3aaa1d0d0723d91e368
 https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.17-h717163a_0.conda#000e85703f0fd9594c81710dd5066471

--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - autoflake
   - black
   - isort
+  - just
   - pre-commit
   - condastats>=0.2.1
   - s3fs>=2025.3.2

--- a/justfile
+++ b/justfile
@@ -1,0 +1,62 @@
+# justfile — developer conveniences for sagemaker-distribution.
+# Requires `just` (added to environment.yml) and Docker. Run `just --list` to see recipes.
+
+# List available recipes.
+default:
+    @just --list
+
+# Regenerate both {cpu,gpu}.env.out lockfiles for a version. e.g. `just update-outfiles 4.5.0`
+update-outfiles version: (update-cpu-outfile version) (update-gpu-outfile version)
+
+# Regenerate cpu.env.out for a version.
+update-cpu-outfile version:
+    @just _update-outfile {{version}} cpu
+
+# Regenerate gpu.env.out for a version.
+update-gpu-outfile version:
+    @just _update-outfile {{version}} gpu
+
+# Regenerate a single <image_type> (cpu|gpu) .env.out for <version>.
+#
+# A lockfile is just the fully-resolved base conda environment, so this reproduces exactly what
+# the image build does to produce it: solve the {cpu,gpu}.env.in (+ pinned_env.in, plus the CUDA
+# arg_based_env.in for gpu) in the matching mambaorg/micromamba base image, then record it with
+# `micromamba env export --explicit`. No full image build and no GPU hardware — GPU packages
+# resolve against the CONDA_OVERRIDE_CUDA virtual package.
+#
+# The base images / CUDA version match src/config.py for SMD major v4.
+_update-outfile version image_type:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    version="{{version}}"
+    image_type="{{image_type}}"
+    version_dir="build_artifacts/v${version%%.*}/v${version%.*}/v${version}"
+    if [ ! -d "$version_dir" ]; then
+        echo "No version directory found at $version_dir" >&2
+        exit 1
+    fi
+    if [ "$image_type" = "gpu" ]; then
+        base_image="mambaorg/micromamba:cuda12.9.1-ubuntu24.04"
+        cuda_override="12.9"
+        arg_based="gpu.arg_based_env.in"
+    elif [ "$image_type" = "cpu" ]; then
+        base_image="mambaorg/micromamba:ubuntu24.04"
+        cuda_override=""
+        arg_based=""
+    else
+        echo "image_type must be 'cpu' or 'gpu', got '$image_type'" >&2
+        exit 1
+    fi
+    echo "Regenerating ${image_type}.env.out for $version in $base_image ..." >&2
+    # Solve inside the base image (env.in append happens on a writable copy), export the lock to
+    # stdout, and capture it into the .env.out. Install chatter goes to stderr so stdout is clean.
+    docker run --rm -e CONDA_OVERRIDE_CUDA="$cuda_override" \
+        -v "$PWD/$version_dir:/work:ro" "$base_image" bash -c "
+            set -euo pipefail
+            cp /work/${image_type}.env.in /work/${image_type}.pinned_env.in /tmp/
+            if [ -n '${arg_based}' ]; then cat /work/${arg_based} >> /tmp/${image_type}.env.in; fi
+            micromamba install -y --name base \
+                --file /tmp/${image_type}.env.in --file /tmp/${image_type}.pinned_env.in 1>&2
+            micromamba env export --name base --explicit
+        " > "$version_dir/${image_type}.env.out"
+    echo "Wrote $version_dir/${image_type}.env.out" >&2


### PR DESCRIPTION
## Motivation

Regenerating a version's `.env.out` lockfiles today means running the full `src/main.py build`, which builds the entire image (CPU and GPU) just to end up calling `micromamba env export --explicit` on the base env. That is far more than is needed to refresh a lock after editing an `.env.in` (e.g. bumping a dependency or pinning a channel), and it isn't discoverable.

## Summary

Adds a top-level `justfile` and adds `just` to the dev `environment.yml`. A lockfile is just the fully-resolved base conda environment, so the recipe reproduces exactly that: it solves the `{cpu,gpu}.env.in` (plus `pinned_env.in`, and the CUDA `arg_based_env.in` for GPU) in the matching `mambaorg/micromamba` base image and records it with `micromamba env export --explicit`. No full image build, and no GPU hardware — GPU packages resolve against the `CONDA_OVERRIDE_CUDA` virtual package.

Recipes:
- `just update-cpu-outfile <version>`
- `just update-gpu-outfile <version>`
- `just update-outfiles <version>` (both)

You can verify it against an unchanged `.env.in`: regenerating should leave the committed `.env.out` unchanged apart from packages that legitimately have newer builds on conda-forge.