### PR TITLE
Re-enable Jupyter AI in the start-jupyter-server templates for v4.1–v4.5

### DIFF
--- a/template/v4/v4.1/Dockerfile
+++ b/template/v4/v4.1/Dockerfile
@@ -221,11 +221,7 @@ RUN if [[ -z $ARG_BASED_ENV_IN_FILENAME ]] ; \
     cp -a ${SYSTEM_PYTHON_PATH}/sagemaker_studio_analytics_extension/patches/reliablehttpclient.py ${SYSTEM_PYTHON_PATH}/sparkmagic/livyclientlib/reliablehttpclient.py && \
     sed -i 's=  "python"=  "/opt/conda/bin/python"=g'  /opt/conda/share/jupyter/kernels/pysparkkernel/kernel.json /opt/conda/share/jupyter/kernels/sparkkernel/kernel.json && \
     sed -i 's="Spark"="SparkMagic Spark"=g'  /opt/conda/share/jupyter/kernels/sparkkernel/kernel.json && \
-    sed -i 's="PySpark"="SparkMagic PySpark"=g'  /opt/conda/share/jupyter/kernels/pysparkkernel/kernel.json && \
-    # Configure RTC - disable jupyter_collaboration by default
-    jupyter labextension disable @jupyter/collaboration-extension && \
-    # Disable docprovider-extension for v3 and above images
-    jupyter labextension disable @jupyter/docprovider-extension
+    sed -i 's="PySpark"="SparkMagic PySpark"=g'  /opt/conda/share/jupyter/kernels/pysparkkernel/kernel.json
 
 # Patch glue kernels to use kernel wrapper
 COPY patch_glue_pyspark.json /opt/conda/share/jupyter/kernels/glue_pyspark/kernel.json

--- a/template/v4/v4.1/dirs/etc/sagemaker/jupyter/private/jupyter_server_config.d/zzz_disable_rtc.json
+++ b/template/v4/v4.1/dirs/etc/sagemaker/jupyter/private/jupyter_server_config.d/zzz_disable_rtc.json
@@ -1,0 +1,7 @@
+{
+    "ServerApp": {
+        "jpserver_extensions": {
+            "jupyter_server_ydoc": false
+        }
+    }
+}

--- a/template/v4/v4.1/dirs/etc/sagemaker/jupyter/private/labconfig/page_config.json
+++ b/template/v4/v4.1/dirs/etc/sagemaker/jupyter/private/labconfig/page_config.json
@@ -1,0 +1,6 @@
+{
+    "disabledExtensions": {
+        "@jupyter/collaboration-extension": true,
+        "@jupyter/docprovider-extension": true
+    }
+}

--- a/template/v4/v4.1/dirs/etc/sagemaker/jupyter/shared/jupyter_server_config.d/zzz_disable_jai.json
+++ b/template/v4/v4.1/dirs/etc/sagemaker/jupyter/shared/jupyter_server_config.d/zzz_disable_jai.json
@@ -1,0 +1,16 @@
+{
+    "ServerApp": {
+        "jpserver_extensions": {
+            "jupyter_ai": false,
+            "jupyter_ai_acp_client": false,
+            "jupyter_ai_tools": false,
+            "jupyter_ai_persona_manager": false,
+            "jupyter_ai_router": false,
+            "jupyter_ai_chat_commands": false,
+            "jupyter_server_mcp": false,
+            "jupyterlab_chat": false,
+            "jupyterlab_commands_toolkit": false,
+            "jupyter_live_content": false
+        }
+    }
+}

--- a/template/v4/v4.1/dirs/etc/sagemaker/jupyter/shared/labconfig/page_config.json
+++ b/template/v4/v4.1/dirs/etc/sagemaker/jupyter/shared/labconfig/page_config.json
@@ -1,7 +1,5 @@
 {
     "disabledExtensions": {
-        "@jupyter/collaboration-extension": false,
-        "@jupyter/docprovider-extension": false,
         "jupyterlab-chat-extension": true,
         "@jupyter-ai/router": true,
         "@jupyter-ai/persona-manager": true,

--- a/template/v4/v4.1/dirs/etc/sagemaker/jupyter/shared/labconfig/page_config.json
+++ b/template/v4/v4.1/dirs/etc/sagemaker/jupyter/shared/labconfig/page_config.json
@@ -1,0 +1,16 @@
+{
+    "disabledExtensions": {
+        "@jupyter/collaboration-extension": false,
+        "@jupyter/docprovider-extension": false,
+        "jupyterlab-chat-extension": true,
+        "@jupyter-ai/router": true,
+        "@jupyter-ai/persona-manager": true,
+        "@jupyter-ai/acp-client": true,
+        "@jupyter-ai/chat-commands": true,
+        "jupyterlab-commands-toolkit": true,
+        "jupyterlab-ai-commands": true,
+        "@jupyter-ai-contrib/live-content": true,
+        "jupyterlab-diff": true,
+        "jupyterlab-cell-input-footer-extension": true
+    }
+}

--- a/template/v4/v4.1/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.1/dirs/usr/local/bin/start-jupyter-server
@@ -52,8 +52,9 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
   jupyter labextension enable @jupyter/collaboration-extension
   jupyter labextension enable @jupyter/docprovider-extension
   jupyter server extension enable jupyter_server_ydoc
-  # Disable chat icon in shared spaces
-  jupyter labextension disable jupyterlab-chat-extension
+  # Jupyter AI is not intended for SMAI shared spaces.
+  micromamba remove -y jupyter-ai jupyter-ai-router jupyter-ai-persona-manager \
+    jupyter-ai-acp-client jupyter-ai-chat-commands jupyter-ai-tools jupyterlab-chat
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   # SAGEMAKER_SPACE_TYPE_LOWERCASE flag is used to determine if the server should start

--- a/template/v4/v4.1/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.1/dirs/usr/local/bin/start-jupyter-server
@@ -72,6 +72,7 @@ elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
   # Remove real-time collaboration in private spaces
   if [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
     micromamba remove -y jupyter-collaboration
+    jupyter server extension disable jupyter_server_ydoc
   fi
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.

--- a/template/v4/v4.1/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.1/dirs/usr/local/bin/start-jupyter-server
@@ -48,13 +48,9 @@ fi
 
 # Start Jupyter server in rtc mode for shared spaces (skip in recovery mode)
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ] && [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
-  # Enable real-time collaboration extensions for shared spaces only
-  jupyter labextension enable @jupyter/collaboration-extension
-  jupyter labextension enable @jupyter/docprovider-extension
-  jupyter server extension enable jupyter_server_ydoc
-  # Jupyter AI is not intended for SMAI shared spaces.
-  micromamba remove -y jupyter-ai jupyter-ai-router jupyter-ai-persona-manager \
-    jupyter-ai-acp-client jupyter-ai-chat-commands jupyter-ai-tools jupyterlab-chat
+  # SMAI shared: enable RTC and disable Jupyter AI via static config.
+  cp /etc/sagemaker/jupyter/shared/labconfig/page_config.json /opt/conda/share/jupyter/lab/settings/page_config.json
+  cp /etc/sagemaker/jupyter/shared/jupyter_server_config.d/zzz_disable_jai.json /opt/conda/etc/jupyter/jupyter_server_config.d/
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   # SAGEMAKER_SPACE_TYPE_LOWERCASE flag is used to determine if the server should start
@@ -69,10 +65,10 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 
 # Start Jupyter server
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
-  # Remove real-time collaboration in private spaces
+  # Disable real-time collaboration in private spaces via static config.
   if [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
-    micromamba remove -y jupyter-collaboration
-    jupyter server extension disable jupyter_server_ydoc
+    cp /etc/sagemaker/jupyter/private/labconfig/page_config.json /opt/conda/share/jupyter/lab/settings/page_config.json
+    cp /etc/sagemaker/jupyter/private/jupyter_server_config.d/zzz_disable_rtc.json /opt/conda/etc/jupyter/jupyter_server_config.d/
   fi
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.

--- a/template/v4/v4.1/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.1/dirs/usr/local/bin/start-jupyter-server
@@ -68,6 +68,10 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 
 # Start Jupyter server
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
+  # Remove real-time collaboration in private spaces
+  if [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
+    micromamba remove -y jupyter-collaboration
+  fi
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   exec jupyter lab --ip 0.0.0.0 --port 8888 \

--- a/template/v4/v4.1/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.1/dirs/usr/local/bin/start-jupyter-server
@@ -48,6 +48,10 @@ fi
 
 # Start Jupyter server in rtc mode for shared spaces (skip in recovery mode)
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ] && [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
+  # Enable real-time collaboration extensions for shared spaces only
+  jupyter labextension enable @jupyter/collaboration-extension
+  jupyter labextension enable @jupyter/docprovider-extension
+  jupyter server extension enable jupyter_server_ydoc
   # Disable chat icon in shared spaces
   jupyter labextension disable jupyterlab-chat-extension
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
@@ -64,10 +68,6 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 
 # Start Jupyter server
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
-  # RTC stays disabled in private spaces
-  jupyter labextension disable @jupyter/collaboration-extension
-  jupyter labextension disable @jupyter/docprovider-extension
-  jupyter server extension disable jupyter_server_ydoc
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   exec jupyter lab --ip 0.0.0.0 --port 8888 \

--- a/template/v4/v4.1/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.1/dirs/usr/local/bin/start-jupyter-server
@@ -48,11 +48,6 @@ fi
 
 # Start Jupyter server in rtc mode for shared spaces (skip in recovery mode)
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ] && [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
-  # Remove JSD and Jupyter AI, then re-enable native Jupyter Collaboration
-  micromamba remove -y jupyter-ai jupyter_server_documents jupyterlab-chat
-  jupyter labextension enable @jupyter/collaboration-extension
-  jupyter labextension enable @jupyter/docprovider-extension
-  jupyter server extension enable jupyter_server_ydoc
   # Disable chat icon in shared spaces
   jupyter labextension disable jupyterlab-chat-extension
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
@@ -69,9 +64,10 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 
 # Start Jupyter server
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
-  if [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
-    micromamba remove -y jupyter-ai jupyter_server_documents jupyter-collaboration jupyterlab-chat
-  fi
+  # RTC stays disabled in private spaces
+  jupyter labextension disable @jupyter/collaboration-extension
+  jupyter labextension disable @jupyter/docprovider-extension
+  jupyter server extension disable jupyter_server_ydoc
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   exec jupyter lab --ip 0.0.0.0 --port 8888 \

--- a/template/v4/v4.2/Dockerfile
+++ b/template/v4/v4.2/Dockerfile
@@ -221,11 +221,7 @@ RUN if [[ -z $ARG_BASED_ENV_IN_FILENAME ]] ; \
     cp -a ${SYSTEM_PYTHON_PATH}/sagemaker_studio_analytics_extension/patches/reliablehttpclient.py ${SYSTEM_PYTHON_PATH}/sparkmagic/livyclientlib/reliablehttpclient.py && \
     sed -i 's=  "python"=  "/opt/conda/bin/python"=g'  /opt/conda/share/jupyter/kernels/pysparkkernel/kernel.json /opt/conda/share/jupyter/kernels/sparkkernel/kernel.json && \
     sed -i 's="Spark"="SparkMagic Spark"=g'  /opt/conda/share/jupyter/kernels/sparkkernel/kernel.json && \
-    sed -i 's="PySpark"="SparkMagic PySpark"=g'  /opt/conda/share/jupyter/kernels/pysparkkernel/kernel.json && \
-    # Configure RTC - disable jupyter_collaboration by default
-    jupyter labextension disable @jupyter/collaboration-extension && \
-    # Disable docprovider-extension for v3 and above images
-    jupyter labextension disable @jupyter/docprovider-extension
+    sed -i 's="PySpark"="SparkMagic PySpark"=g'  /opt/conda/share/jupyter/kernels/pysparkkernel/kernel.json
 
 # Patch glue kernels to use kernel wrapper
 COPY patch_glue_pyspark.json /opt/conda/share/jupyter/kernels/glue_pyspark/kernel.json

--- a/template/v4/v4.2/dirs/etc/sagemaker/jupyter/private/jupyter_server_config.d/zzz_disable_rtc.json
+++ b/template/v4/v4.2/dirs/etc/sagemaker/jupyter/private/jupyter_server_config.d/zzz_disable_rtc.json
@@ -1,0 +1,7 @@
+{
+    "ServerApp": {
+        "jpserver_extensions": {
+            "jupyter_server_ydoc": false
+        }
+    }
+}

--- a/template/v4/v4.2/dirs/etc/sagemaker/jupyter/private/labconfig/page_config.json
+++ b/template/v4/v4.2/dirs/etc/sagemaker/jupyter/private/labconfig/page_config.json
@@ -1,0 +1,6 @@
+{
+    "disabledExtensions": {
+        "@jupyter/collaboration-extension": true,
+        "@jupyter/docprovider-extension": true
+    }
+}

--- a/template/v4/v4.2/dirs/etc/sagemaker/jupyter/shared/jupyter_server_config.d/zzz_disable_jai.json
+++ b/template/v4/v4.2/dirs/etc/sagemaker/jupyter/shared/jupyter_server_config.d/zzz_disable_jai.json
@@ -1,0 +1,16 @@
+{
+    "ServerApp": {
+        "jpserver_extensions": {
+            "jupyter_ai": false,
+            "jupyter_ai_acp_client": false,
+            "jupyter_ai_tools": false,
+            "jupyter_ai_persona_manager": false,
+            "jupyter_ai_router": false,
+            "jupyter_ai_chat_commands": false,
+            "jupyter_server_mcp": false,
+            "jupyterlab_chat": false,
+            "jupyterlab_commands_toolkit": false,
+            "jupyter_live_content": false
+        }
+    }
+}

--- a/template/v4/v4.2/dirs/etc/sagemaker/jupyter/shared/labconfig/page_config.json
+++ b/template/v4/v4.2/dirs/etc/sagemaker/jupyter/shared/labconfig/page_config.json
@@ -1,7 +1,5 @@
 {
     "disabledExtensions": {
-        "@jupyter/collaboration-extension": false,
-        "@jupyter/docprovider-extension": false,
         "jupyterlab-chat-extension": true,
         "@jupyter-ai/router": true,
         "@jupyter-ai/persona-manager": true,

--- a/template/v4/v4.2/dirs/etc/sagemaker/jupyter/shared/labconfig/page_config.json
+++ b/template/v4/v4.2/dirs/etc/sagemaker/jupyter/shared/labconfig/page_config.json
@@ -1,0 +1,16 @@
+{
+    "disabledExtensions": {
+        "@jupyter/collaboration-extension": false,
+        "@jupyter/docprovider-extension": false,
+        "jupyterlab-chat-extension": true,
+        "@jupyter-ai/router": true,
+        "@jupyter-ai/persona-manager": true,
+        "@jupyter-ai/acp-client": true,
+        "@jupyter-ai/chat-commands": true,
+        "jupyterlab-commands-toolkit": true,
+        "jupyterlab-ai-commands": true,
+        "@jupyter-ai-contrib/live-content": true,
+        "jupyterlab-diff": true,
+        "jupyterlab-cell-input-footer-extension": true
+    }
+}

--- a/template/v4/v4.2/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.2/dirs/usr/local/bin/start-jupyter-server
@@ -52,8 +52,9 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
   jupyter labextension enable @jupyter/collaboration-extension
   jupyter labextension enable @jupyter/docprovider-extension
   jupyter server extension enable jupyter_server_ydoc
-  # Disable chat icon in shared spaces
-  jupyter labextension disable jupyterlab-chat-extension
+  # Jupyter AI is not intended for SMAI shared spaces.
+  micromamba remove -y jupyter-ai jupyter-ai-router jupyter-ai-persona-manager \
+    jupyter-ai-acp-client jupyter-ai-chat-commands jupyter-ai-tools jupyterlab-chat
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   # SAGEMAKER_SPACE_TYPE_LOWERCASE flag is used to determine if the server should start

--- a/template/v4/v4.2/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.2/dirs/usr/local/bin/start-jupyter-server
@@ -72,6 +72,7 @@ elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
   # Remove real-time collaboration in private spaces
   if [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
     micromamba remove -y jupyter-collaboration
+    jupyter server extension disable jupyter_server_ydoc
   fi
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.

--- a/template/v4/v4.2/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.2/dirs/usr/local/bin/start-jupyter-server
@@ -48,13 +48,9 @@ fi
 
 # Start Jupyter server in rtc mode for shared spaces (skip in recovery mode)
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ] && [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
-  # Enable real-time collaboration extensions for shared spaces only
-  jupyter labextension enable @jupyter/collaboration-extension
-  jupyter labextension enable @jupyter/docprovider-extension
-  jupyter server extension enable jupyter_server_ydoc
-  # Jupyter AI is not intended for SMAI shared spaces.
-  micromamba remove -y jupyter-ai jupyter-ai-router jupyter-ai-persona-manager \
-    jupyter-ai-acp-client jupyter-ai-chat-commands jupyter-ai-tools jupyterlab-chat
+  # SMAI shared: enable RTC and disable Jupyter AI via static config.
+  cp /etc/sagemaker/jupyter/shared/labconfig/page_config.json /opt/conda/share/jupyter/lab/settings/page_config.json
+  cp /etc/sagemaker/jupyter/shared/jupyter_server_config.d/zzz_disable_jai.json /opt/conda/etc/jupyter/jupyter_server_config.d/
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   # SAGEMAKER_SPACE_TYPE_LOWERCASE flag is used to determine if the server should start
@@ -69,10 +65,10 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 
 # Start Jupyter server
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
-  # Remove real-time collaboration in private spaces
+  # Disable real-time collaboration in private spaces via static config.
   if [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
-    micromamba remove -y jupyter-collaboration
-    jupyter server extension disable jupyter_server_ydoc
+    cp /etc/sagemaker/jupyter/private/labconfig/page_config.json /opt/conda/share/jupyter/lab/settings/page_config.json
+    cp /etc/sagemaker/jupyter/private/jupyter_server_config.d/zzz_disable_rtc.json /opt/conda/etc/jupyter/jupyter_server_config.d/
   fi
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.

--- a/template/v4/v4.2/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.2/dirs/usr/local/bin/start-jupyter-server
@@ -68,6 +68,10 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 
 # Start Jupyter server
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
+  # Remove real-time collaboration in private spaces
+  if [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
+    micromamba remove -y jupyter-collaboration
+  fi
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   exec jupyter lab --ip 0.0.0.0 --port 8888 \

--- a/template/v4/v4.2/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.2/dirs/usr/local/bin/start-jupyter-server
@@ -48,6 +48,10 @@ fi
 
 # Start Jupyter server in rtc mode for shared spaces (skip in recovery mode)
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ] && [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
+  # Enable real-time collaboration extensions for shared spaces only
+  jupyter labextension enable @jupyter/collaboration-extension
+  jupyter labextension enable @jupyter/docprovider-extension
+  jupyter server extension enable jupyter_server_ydoc
   # Disable chat icon in shared spaces
   jupyter labextension disable jupyterlab-chat-extension
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
@@ -64,10 +68,6 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 
 # Start Jupyter server
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
-  # RTC stays disabled in private spaces
-  jupyter labextension disable @jupyter/collaboration-extension
-  jupyter labextension disable @jupyter/docprovider-extension
-  jupyter server extension disable jupyter_server_ydoc
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   exec jupyter lab --ip 0.0.0.0 --port 8888 \

--- a/template/v4/v4.2/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.2/dirs/usr/local/bin/start-jupyter-server
@@ -48,11 +48,6 @@ fi
 
 # Start Jupyter server in rtc mode for shared spaces (skip in recovery mode)
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ] && [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
-  # Remove JSD and Jupyter AI, then re-enable native Jupyter Collaboration
-  micromamba remove -y jupyter-ai jupyter_server_documents jupyterlab-chat
-  jupyter labextension enable @jupyter/collaboration-extension
-  jupyter labextension enable @jupyter/docprovider-extension
-  jupyter server extension enable jupyter_server_ydoc
   # Disable chat icon in shared spaces
   jupyter labextension disable jupyterlab-chat-extension
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
@@ -69,9 +64,10 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 
 # Start Jupyter server
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
-  if [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
-    micromamba remove -y jupyter-ai jupyter_server_documents jupyter-collaboration jupyterlab-chat
-  fi
+  # RTC stays disabled in private spaces
+  jupyter labextension disable @jupyter/collaboration-extension
+  jupyter labextension disable @jupyter/docprovider-extension
+  jupyter server extension disable jupyter_server_ydoc
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   exec jupyter lab --ip 0.0.0.0 --port 8888 \

--- a/template/v4/v4.3/Dockerfile
+++ b/template/v4/v4.3/Dockerfile
@@ -221,11 +221,7 @@ RUN if [[ -z $ARG_BASED_ENV_IN_FILENAME ]] ; \
     cp -a ${SYSTEM_PYTHON_PATH}/sagemaker_studio_analytics_extension/patches/reliablehttpclient.py ${SYSTEM_PYTHON_PATH}/sparkmagic/livyclientlib/reliablehttpclient.py && \
     sed -i 's=  "python"=  "/opt/conda/bin/python"=g'  /opt/conda/share/jupyter/kernels/pysparkkernel/kernel.json /opt/conda/share/jupyter/kernels/sparkkernel/kernel.json && \
     sed -i 's="Spark"="SparkMagic Spark"=g'  /opt/conda/share/jupyter/kernels/sparkkernel/kernel.json && \
-    sed -i 's="PySpark"="SparkMagic PySpark"=g'  /opt/conda/share/jupyter/kernels/pysparkkernel/kernel.json && \
-    # Configure RTC - disable jupyter_collaboration by default
-    jupyter labextension disable @jupyter/collaboration-extension && \
-    # Disable docprovider-extension for v3 and above images
-    jupyter labextension disable @jupyter/docprovider-extension
+    sed -i 's="PySpark"="SparkMagic PySpark"=g'  /opt/conda/share/jupyter/kernels/pysparkkernel/kernel.json
 
 # Patch glue kernels to use kernel wrapper
 COPY patch_glue_pyspark.json /opt/conda/share/jupyter/kernels/glue_pyspark/kernel.json

--- a/template/v4/v4.3/dirs/etc/sagemaker/jupyter/private/jupyter_server_config.d/zzz_disable_rtc.json
+++ b/template/v4/v4.3/dirs/etc/sagemaker/jupyter/private/jupyter_server_config.d/zzz_disable_rtc.json
@@ -1,0 +1,7 @@
+{
+    "ServerApp": {
+        "jpserver_extensions": {
+            "jupyter_server_ydoc": false
+        }
+    }
+}

--- a/template/v4/v4.3/dirs/etc/sagemaker/jupyter/private/labconfig/page_config.json
+++ b/template/v4/v4.3/dirs/etc/sagemaker/jupyter/private/labconfig/page_config.json
@@ -1,0 +1,6 @@
+{
+    "disabledExtensions": {
+        "@jupyter/collaboration-extension": true,
+        "@jupyter/docprovider-extension": true
+    }
+}

--- a/template/v4/v4.3/dirs/etc/sagemaker/jupyter/shared/jupyter_server_config.d/zzz_disable_jai.json
+++ b/template/v4/v4.3/dirs/etc/sagemaker/jupyter/shared/jupyter_server_config.d/zzz_disable_jai.json
@@ -1,0 +1,16 @@
+{
+    "ServerApp": {
+        "jpserver_extensions": {
+            "jupyter_ai": false,
+            "jupyter_ai_acp_client": false,
+            "jupyter_ai_tools": false,
+            "jupyter_ai_persona_manager": false,
+            "jupyter_ai_router": false,
+            "jupyter_ai_chat_commands": false,
+            "jupyter_server_mcp": false,
+            "jupyterlab_chat": false,
+            "jupyterlab_commands_toolkit": false,
+            "jupyter_live_content": false
+        }
+    }
+}

--- a/template/v4/v4.3/dirs/etc/sagemaker/jupyter/shared/labconfig/page_config.json
+++ b/template/v4/v4.3/dirs/etc/sagemaker/jupyter/shared/labconfig/page_config.json
@@ -1,7 +1,5 @@
 {
     "disabledExtensions": {
-        "@jupyter/collaboration-extension": false,
-        "@jupyter/docprovider-extension": false,
         "jupyterlab-chat-extension": true,
         "@jupyter-ai/router": true,
         "@jupyter-ai/persona-manager": true,

--- a/template/v4/v4.3/dirs/etc/sagemaker/jupyter/shared/labconfig/page_config.json
+++ b/template/v4/v4.3/dirs/etc/sagemaker/jupyter/shared/labconfig/page_config.json
@@ -1,0 +1,16 @@
+{
+    "disabledExtensions": {
+        "@jupyter/collaboration-extension": false,
+        "@jupyter/docprovider-extension": false,
+        "jupyterlab-chat-extension": true,
+        "@jupyter-ai/router": true,
+        "@jupyter-ai/persona-manager": true,
+        "@jupyter-ai/acp-client": true,
+        "@jupyter-ai/chat-commands": true,
+        "jupyterlab-commands-toolkit": true,
+        "jupyterlab-ai-commands": true,
+        "@jupyter-ai-contrib/live-content": true,
+        "jupyterlab-diff": true,
+        "jupyterlab-cell-input-footer-extension": true
+    }
+}

--- a/template/v4/v4.3/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.3/dirs/usr/local/bin/start-jupyter-server
@@ -52,8 +52,9 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
   jupyter labextension enable @jupyter/collaboration-extension
   jupyter labextension enable @jupyter/docprovider-extension
   jupyter server extension enable jupyter_server_ydoc
-  # Disable chat icon in shared spaces
-  jupyter labextension disable jupyterlab-chat-extension
+  # Jupyter AI is not intended for SMAI shared spaces.
+  micromamba remove -y jupyter-ai jupyter-ai-router jupyter-ai-persona-manager \
+    jupyter-ai-acp-client jupyter-ai-chat-commands jupyter-ai-tools jupyterlab-chat
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   # SAGEMAKER_SPACE_TYPE_LOWERCASE flag is used to determine if the server should start

--- a/template/v4/v4.3/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.3/dirs/usr/local/bin/start-jupyter-server
@@ -72,6 +72,7 @@ elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
   # Remove real-time collaboration in private spaces
   if [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
     micromamba remove -y jupyter-collaboration
+    jupyter server extension disable jupyter_server_ydoc
   fi
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.

--- a/template/v4/v4.3/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.3/dirs/usr/local/bin/start-jupyter-server
@@ -48,13 +48,9 @@ fi
 
 # Start Jupyter server in rtc mode for shared spaces (skip in recovery mode)
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ] && [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
-  # Enable real-time collaboration extensions for shared spaces only
-  jupyter labextension enable @jupyter/collaboration-extension
-  jupyter labextension enable @jupyter/docprovider-extension
-  jupyter server extension enable jupyter_server_ydoc
-  # Jupyter AI is not intended for SMAI shared spaces.
-  micromamba remove -y jupyter-ai jupyter-ai-router jupyter-ai-persona-manager \
-    jupyter-ai-acp-client jupyter-ai-chat-commands jupyter-ai-tools jupyterlab-chat
+  # SMAI shared: enable RTC and disable Jupyter AI via static config.
+  cp /etc/sagemaker/jupyter/shared/labconfig/page_config.json /opt/conda/share/jupyter/lab/settings/page_config.json
+  cp /etc/sagemaker/jupyter/shared/jupyter_server_config.d/zzz_disable_jai.json /opt/conda/etc/jupyter/jupyter_server_config.d/
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   # SAGEMAKER_SPACE_TYPE_LOWERCASE flag is used to determine if the server should start
@@ -69,10 +65,10 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 
 # Start Jupyter server
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
-  # Remove real-time collaboration in private spaces
+  # Disable real-time collaboration in private spaces via static config.
   if [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
-    micromamba remove -y jupyter-collaboration
-    jupyter server extension disable jupyter_server_ydoc
+    cp /etc/sagemaker/jupyter/private/labconfig/page_config.json /opt/conda/share/jupyter/lab/settings/page_config.json
+    cp /etc/sagemaker/jupyter/private/jupyter_server_config.d/zzz_disable_rtc.json /opt/conda/etc/jupyter/jupyter_server_config.d/
   fi
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.

--- a/template/v4/v4.3/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.3/dirs/usr/local/bin/start-jupyter-server
@@ -68,6 +68,10 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 
 # Start Jupyter server
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
+  # Remove real-time collaboration in private spaces
+  if [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
+    micromamba remove -y jupyter-collaboration
+  fi
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   exec jupyter lab --ip 0.0.0.0 --port 8888 \

--- a/template/v4/v4.3/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.3/dirs/usr/local/bin/start-jupyter-server
@@ -48,6 +48,10 @@ fi
 
 # Start Jupyter server in rtc mode for shared spaces (skip in recovery mode)
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ] && [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
+  # Enable real-time collaboration extensions for shared spaces only
+  jupyter labextension enable @jupyter/collaboration-extension
+  jupyter labextension enable @jupyter/docprovider-extension
+  jupyter server extension enable jupyter_server_ydoc
   # Disable chat icon in shared spaces
   jupyter labextension disable jupyterlab-chat-extension
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
@@ -64,10 +68,6 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 
 # Start Jupyter server
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
-  # RTC stays disabled in private spaces
-  jupyter labextension disable @jupyter/collaboration-extension
-  jupyter labextension disable @jupyter/docprovider-extension
-  jupyter server extension disable jupyter_server_ydoc
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   exec jupyter lab --ip 0.0.0.0 --port 8888 \

--- a/template/v4/v4.3/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.3/dirs/usr/local/bin/start-jupyter-server
@@ -48,11 +48,6 @@ fi
 
 # Start Jupyter server in rtc mode for shared spaces (skip in recovery mode)
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ] && [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
-  # Remove JSD and Jupyter AI, then re-enable native Jupyter Collaboration
-  micromamba remove -y jupyter-ai jupyter_server_documents jupyterlab-chat
-  jupyter labextension enable @jupyter/collaboration-extension
-  jupyter labextension enable @jupyter/docprovider-extension
-  jupyter server extension enable jupyter_server_ydoc
   # Disable chat icon in shared spaces
   jupyter labextension disable jupyterlab-chat-extension
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
@@ -69,9 +64,10 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 
 # Start Jupyter server
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
-  if [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
-    micromamba remove -y jupyter-ai jupyter_server_documents jupyter-collaboration jupyterlab-chat
-  fi
+  # RTC stays disabled in private spaces
+  jupyter labextension disable @jupyter/collaboration-extension
+  jupyter labextension disable @jupyter/docprovider-extension
+  jupyter server extension disable jupyter_server_ydoc
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   exec jupyter lab --ip 0.0.0.0 --port 8888 \

--- a/template/v4/v4.4/Dockerfile
+++ b/template/v4/v4.4/Dockerfile
@@ -221,11 +221,7 @@ RUN if [[ -z $ARG_BASED_ENV_IN_FILENAME ]] ; \
     cp -a ${SYSTEM_PYTHON_PATH}/sagemaker_studio_analytics_extension/patches/reliablehttpclient.py ${SYSTEM_PYTHON_PATH}/sparkmagic/livyclientlib/reliablehttpclient.py && \
     sed -i 's=  "python"=  "/opt/conda/bin/python"=g'  /opt/conda/share/jupyter/kernels/pysparkkernel/kernel.json /opt/conda/share/jupyter/kernels/sparkkernel/kernel.json && \
     sed -i 's="Spark"="SparkMagic Spark"=g'  /opt/conda/share/jupyter/kernels/sparkkernel/kernel.json && \
-    sed -i 's="PySpark"="SparkMagic PySpark"=g'  /opt/conda/share/jupyter/kernels/pysparkkernel/kernel.json && \
-    # Configure RTC - disable jupyter_collaboration by default
-    jupyter labextension disable @jupyter/collaboration-extension && \
-    # Disable docprovider-extension for v3 and above images
-    jupyter labextension disable @jupyter/docprovider-extension
+    sed -i 's="PySpark"="SparkMagic PySpark"=g'  /opt/conda/share/jupyter/kernels/pysparkkernel/kernel.json
 
 
 # Patch glue kernels to use kernel wrapper

--- a/template/v4/v4.4/dirs/etc/sagemaker/jupyter/private/jupyter_server_config.d/zzz_disable_rtc.json
+++ b/template/v4/v4.4/dirs/etc/sagemaker/jupyter/private/jupyter_server_config.d/zzz_disable_rtc.json
@@ -1,0 +1,7 @@
+{
+    "ServerApp": {
+        "jpserver_extensions": {
+            "jupyter_server_ydoc": false
+        }
+    }
+}

--- a/template/v4/v4.4/dirs/etc/sagemaker/jupyter/private/labconfig/page_config.json
+++ b/template/v4/v4.4/dirs/etc/sagemaker/jupyter/private/labconfig/page_config.json
@@ -1,0 +1,6 @@
+{
+    "disabledExtensions": {
+        "@jupyter/collaboration-extension": true,
+        "@jupyter/docprovider-extension": true
+    }
+}

--- a/template/v4/v4.4/dirs/etc/sagemaker/jupyter/shared/jupyter_server_config.d/zzz_disable_jai.json
+++ b/template/v4/v4.4/dirs/etc/sagemaker/jupyter/shared/jupyter_server_config.d/zzz_disable_jai.json
@@ -1,0 +1,16 @@
+{
+    "ServerApp": {
+        "jpserver_extensions": {
+            "jupyter_ai": false,
+            "jupyter_ai_acp_client": false,
+            "jupyter_ai_tools": false,
+            "jupyter_ai_persona_manager": false,
+            "jupyter_ai_router": false,
+            "jupyter_ai_chat_commands": false,
+            "jupyter_server_mcp": false,
+            "jupyterlab_chat": false,
+            "jupyterlab_commands_toolkit": false,
+            "jupyter_live_content": false
+        }
+    }
+}

--- a/template/v4/v4.4/dirs/etc/sagemaker/jupyter/shared/labconfig/page_config.json
+++ b/template/v4/v4.4/dirs/etc/sagemaker/jupyter/shared/labconfig/page_config.json
@@ -1,7 +1,5 @@
 {
     "disabledExtensions": {
-        "@jupyter/collaboration-extension": false,
-        "@jupyter/docprovider-extension": false,
         "jupyterlab-chat-extension": true,
         "@jupyter-ai/router": true,
         "@jupyter-ai/persona-manager": true,

--- a/template/v4/v4.4/dirs/etc/sagemaker/jupyter/shared/labconfig/page_config.json
+++ b/template/v4/v4.4/dirs/etc/sagemaker/jupyter/shared/labconfig/page_config.json
@@ -1,0 +1,16 @@
+{
+    "disabledExtensions": {
+        "@jupyter/collaboration-extension": false,
+        "@jupyter/docprovider-extension": false,
+        "jupyterlab-chat-extension": true,
+        "@jupyter-ai/router": true,
+        "@jupyter-ai/persona-manager": true,
+        "@jupyter-ai/acp-client": true,
+        "@jupyter-ai/chat-commands": true,
+        "jupyterlab-commands-toolkit": true,
+        "jupyterlab-ai-commands": true,
+        "@jupyter-ai-contrib/live-content": true,
+        "jupyterlab-diff": true,
+        "jupyterlab-cell-input-footer-extension": true
+    }
+}

--- a/template/v4/v4.4/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.4/dirs/usr/local/bin/start-jupyter-server
@@ -72,6 +72,10 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 
 # Start Jupyter server
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
+  # Remove real-time collaboration in private spaces
+  if [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
+    micromamba remove -y jupyter-collaboration
+  fi
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   exec jupyter lab --ip 0.0.0.0 --port 8888 \

--- a/template/v4/v4.4/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.4/dirs/usr/local/bin/start-jupyter-server
@@ -52,13 +52,9 @@ fi
 
 # Start Jupyter server in rtc mode for shared spaces (skip in recovery mode)
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ] && [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
-  # Enable real-time collaboration extensions for shared spaces only
-  jupyter labextension enable @jupyter/collaboration-extension
-  jupyter labextension enable @jupyter/docprovider-extension
-  jupyter server extension enable jupyter_server_ydoc
-  # Jupyter AI is not intended for SMAI shared spaces.
-  micromamba remove -y jupyter-ai jupyter-ai-router jupyter-ai-persona-manager \
-    jupyter-ai-acp-client jupyter-ai-chat-commands jupyter-ai-tools jupyterlab-chat
+  # SMAI shared: enable RTC and disable Jupyter AI via static config.
+  cp /etc/sagemaker/jupyter/shared/labconfig/page_config.json /opt/conda/share/jupyter/lab/settings/page_config.json
+  cp /etc/sagemaker/jupyter/shared/jupyter_server_config.d/zzz_disable_jai.json /opt/conda/etc/jupyter/jupyter_server_config.d/
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   # SAGEMAKER_SPACE_TYPE_LOWERCASE flag is used to determine if the server should start
@@ -73,10 +69,10 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 
 # Start Jupyter server
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
-  # Remove real-time collaboration in private spaces
+  # Disable real-time collaboration in private spaces via static config.
   if [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
-    micromamba remove -y jupyter-collaboration
-    jupyter server extension disable jupyter_server_ydoc
+    cp /etc/sagemaker/jupyter/private/labconfig/page_config.json /opt/conda/share/jupyter/lab/settings/page_config.json
+    cp /etc/sagemaker/jupyter/private/jupyter_server_config.d/zzz_disable_rtc.json /opt/conda/etc/jupyter/jupyter_server_config.d/
   fi
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.

--- a/template/v4/v4.4/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.4/dirs/usr/local/bin/start-jupyter-server
@@ -52,6 +52,10 @@ fi
 
 # Start Jupyter server in rtc mode for shared spaces (skip in recovery mode)
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ] && [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
+  # Enable real-time collaboration extensions for shared spaces only
+  jupyter labextension enable @jupyter/collaboration-extension
+  jupyter labextension enable @jupyter/docprovider-extension
+  jupyter server extension enable jupyter_server_ydoc
   # Disable chat icon in shared spaces
   jupyter labextension disable jupyterlab-chat-extension
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
@@ -68,10 +72,6 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 
 # Start Jupyter server
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
-  # RTC stays disabled in private spaces
-  jupyter labextension disable @jupyter/collaboration-extension
-  jupyter labextension disable @jupyter/docprovider-extension
-  jupyter server extension disable jupyter_server_ydoc
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   exec jupyter lab --ip 0.0.0.0 --port 8888 \

--- a/template/v4/v4.4/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.4/dirs/usr/local/bin/start-jupyter-server
@@ -52,12 +52,6 @@ fi
 
 # Start Jupyter server in rtc mode for shared spaces (skip in recovery mode)
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ] && [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
-  # Remove JSD and Jupyter AI, then re-enable native Jupyter Collaboration
-  micromamba remove -y jupyter-ai jupyter_server_documents jupyterlab-chat
-  # Enable real-time collaboration extensions for shared spaces only
-  jupyter labextension enable @jupyter/collaboration-extension
-  jupyter labextension enable @jupyter/docprovider-extension
-  jupyter server extension enable jupyter_server_ydoc
   # Disable chat icon in shared spaces
   jupyter labextension disable jupyterlab-chat-extension
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
@@ -74,9 +68,10 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 
 # Start Jupyter server
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
-  if [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
-    micromamba remove -y jupyter-ai jupyter_server_documents jupyter-collaboration jupyterlab-chat
-  fi
+  # RTC stays disabled in private spaces
+  jupyter labextension disable @jupyter/collaboration-extension
+  jupyter labextension disable @jupyter/docprovider-extension
+  jupyter server extension disable jupyter_server_ydoc
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   exec jupyter lab --ip 0.0.0.0 --port 8888 \

--- a/template/v4/v4.4/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.4/dirs/usr/local/bin/start-jupyter-server
@@ -56,8 +56,9 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
   jupyter labextension enable @jupyter/collaboration-extension
   jupyter labextension enable @jupyter/docprovider-extension
   jupyter server extension enable jupyter_server_ydoc
-  # Disable chat icon in shared spaces
-  jupyter labextension disable jupyterlab-chat-extension
+  # Jupyter AI is not intended for SMAI shared spaces.
+  micromamba remove -y jupyter-ai jupyter-ai-router jupyter-ai-persona-manager \
+    jupyter-ai-acp-client jupyter-ai-chat-commands jupyter-ai-tools jupyterlab-chat
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   # SAGEMAKER_SPACE_TYPE_LOWERCASE flag is used to determine if the server should start

--- a/template/v4/v4.4/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.4/dirs/usr/local/bin/start-jupyter-server
@@ -76,6 +76,7 @@ elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
   # Remove real-time collaboration in private spaces
   if [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
     micromamba remove -y jupyter-collaboration
+    jupyter server extension disable jupyter_server_ydoc
   fi
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.

--- a/template/v4/v4.5/dirs/etc/sagemaker/jupyter/private/jupyter_server_config.d/zzz_disable_rtc.json
+++ b/template/v4/v4.5/dirs/etc/sagemaker/jupyter/private/jupyter_server_config.d/zzz_disable_rtc.json
@@ -1,0 +1,7 @@
+{
+    "ServerApp": {
+        "jpserver_extensions": {
+            "jupyter_server_ydoc": false
+        }
+    }
+}

--- a/template/v4/v4.5/dirs/etc/sagemaker/jupyter/private/labconfig/page_config.json
+++ b/template/v4/v4.5/dirs/etc/sagemaker/jupyter/private/labconfig/page_config.json
@@ -1,0 +1,6 @@
+{
+    "disabledExtensions": {
+        "@jupyter/collaboration-extension": true,
+        "@jupyter/docprovider-extension": true
+    }
+}

--- a/template/v4/v4.5/dirs/etc/sagemaker/jupyter/shared/jupyter_server_config.d/zzz_disable_jai.json
+++ b/template/v4/v4.5/dirs/etc/sagemaker/jupyter/shared/jupyter_server_config.d/zzz_disable_jai.json
@@ -1,0 +1,16 @@
+{
+    "ServerApp": {
+        "jpserver_extensions": {
+            "jupyter_ai": false,
+            "jupyter_ai_acp_client": false,
+            "jupyter_ai_tools": false,
+            "jupyter_ai_persona_manager": false,
+            "jupyter_ai_router": false,
+            "jupyter_ai_chat_commands": false,
+            "jupyter_server_mcp": false,
+            "jupyterlab_chat": false,
+            "jupyterlab_commands_toolkit": false,
+            "jupyter_live_content": false
+        }
+    }
+}

--- a/template/v4/v4.5/dirs/etc/sagemaker/jupyter/shared/labconfig/page_config.json
+++ b/template/v4/v4.5/dirs/etc/sagemaker/jupyter/shared/labconfig/page_config.json
@@ -1,7 +1,5 @@
 {
     "disabledExtensions": {
-        "@jupyter/collaboration-extension": false,
-        "@jupyter/docprovider-extension": false,
         "jupyterlab-chat-extension": true,
         "@jupyter-ai/router": true,
         "@jupyter-ai/persona-manager": true,

--- a/template/v4/v4.5/dirs/etc/sagemaker/jupyter/shared/labconfig/page_config.json
+++ b/template/v4/v4.5/dirs/etc/sagemaker/jupyter/shared/labconfig/page_config.json
@@ -1,0 +1,16 @@
+{
+    "disabledExtensions": {
+        "@jupyter/collaboration-extension": false,
+        "@jupyter/docprovider-extension": false,
+        "jupyterlab-chat-extension": true,
+        "@jupyter-ai/router": true,
+        "@jupyter-ai/persona-manager": true,
+        "@jupyter-ai/acp-client": true,
+        "@jupyter-ai/chat-commands": true,
+        "jupyterlab-commands-toolkit": true,
+        "jupyterlab-ai-commands": true,
+        "@jupyter-ai-contrib/live-content": true,
+        "jupyterlab-diff": true,
+        "jupyterlab-cell-input-footer-extension": true
+    }
+}

--- a/template/v4/v4.5/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.5/dirs/usr/local/bin/start-jupyter-server
@@ -50,9 +50,6 @@ if [ -n "$TRUSTED_IDENTITY_PROPOGATION_ENABLED" ]; then
     echo BOTOCORE_EXPERIMENTAL__PLUGINS=S3AccessGrantsPlugin=aws_s3_access_grants_boto3_plugin.s3_access_grants_plugin >> ~/.bashrc
 fi
 
-jupyter labextension enable @jupyter/collaboration-extension
-jupyter labextension enable @jupyter/docprovider-extension
-
 # Start Jupyter server in rtc mode for shared spaces (skip in recovery mode)
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ] && [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
   # Disable chat icon in shared spaces
@@ -71,6 +68,10 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 
 # Start Jupyter server
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
+  # RTC stays disabled in private spaces
+  jupyter labextension disable @jupyter/collaboration-extension
+  jupyter labextension disable @jupyter/docprovider-extension
+  jupyter server extension disable jupyter_server_ydoc
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   exec jupyter lab --ip 0.0.0.0 --port 8888 \

--- a/template/v4/v4.5/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.5/dirs/usr/local/bin/start-jupyter-server
@@ -72,6 +72,10 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 
 # Start Jupyter server
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
+  # Remove real-time collaboration in private spaces
+  if [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
+    micromamba remove -y jupyter-collaboration
+  fi
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   exec jupyter lab --ip 0.0.0.0 --port 8888 \

--- a/template/v4/v4.5/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.5/dirs/usr/local/bin/start-jupyter-server
@@ -52,6 +52,10 @@ fi
 
 # Start Jupyter server in rtc mode for shared spaces (skip in recovery mode)
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ] && [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
+  # Enable real-time collaboration extensions for shared spaces only
+  jupyter labextension enable @jupyter/collaboration-extension
+  jupyter labextension enable @jupyter/docprovider-extension
+  jupyter server extension enable jupyter_server_ydoc
   # Disable chat icon in shared spaces
   jupyter labextension disable jupyterlab-chat-extension
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
@@ -68,10 +72,6 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 
 # Start Jupyter server
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
-  # RTC stays disabled in private spaces
-  jupyter labextension disable @jupyter/collaboration-extension
-  jupyter labextension disable @jupyter/docprovider-extension
-  jupyter server extension disable jupyter_server_ydoc
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   exec jupyter lab --ip 0.0.0.0 --port 8888 \

--- a/template/v4/v4.5/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.5/dirs/usr/local/bin/start-jupyter-server
@@ -76,6 +76,8 @@ elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
   # Remove real-time collaboration in private spaces
   if [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
     micromamba remove -y jupyter-collaboration
+    jupyter labextension disable @jupyter/docprovider-extension
+    jupyter server extension disable jupyter_server_ydoc
   fi
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.

--- a/template/v4/v4.5/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.5/dirs/usr/local/bin/start-jupyter-server
@@ -52,13 +52,9 @@ fi
 
 # Start Jupyter server in rtc mode for shared spaces (skip in recovery mode)
 if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE" == "shared" ] && [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
-  # Enable real-time collaboration extensions for shared spaces only
-  jupyter labextension enable @jupyter/collaboration-extension
-  jupyter labextension enable @jupyter/docprovider-extension
-  jupyter server extension enable jupyter_server_ydoc
-  # Jupyter AI is not intended for SMAI shared spaces.
-  micromamba remove -y jupyter-ai jupyter-ai-router jupyter-ai-persona-manager \
-    jupyter-ai-acp-client jupyter-ai-chat-commands jupyter-ai-tools jupyterlab-chat
+  # SMAI shared: enable RTC and disable Jupyter AI via static config.
+  cp /etc/sagemaker/jupyter/shared/labconfig/page_config.json /opt/conda/share/jupyter/lab/settings/page_config.json
+  cp /etc/sagemaker/jupyter/shared/jupyter_server_config.d/zzz_disable_jai.json /opt/conda/etc/jupyter/jupyter_server_config.d/
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   # SAGEMAKER_SPACE_TYPE_LOWERCASE flag is used to determine if the server should start
@@ -73,11 +69,10 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
 
 # Start Jupyter server
 elif [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ]; then
-  # Remove real-time collaboration in private spaces
+  # Disable real-time collaboration in private spaces via static config.
   if [ -z "$SAGEMAKER_RECOVERY_MODE" ]; then
-    micromamba remove -y jupyter-collaboration
-    jupyter labextension disable @jupyter/docprovider-extension
-    jupyter server extension disable jupyter_server_ydoc
+    cp /etc/sagemaker/jupyter/private/labconfig/page_config.json /opt/conda/share/jupyter/lab/settings/page_config.json
+    cp /etc/sagemaker/jupyter/private/jupyter_server_config.d/zzz_disable_rtc.json /opt/conda/etc/jupyter/jupyter_server_config.d/
   fi
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.

--- a/template/v4/v4.5/dirs/usr/local/bin/start-jupyter-server
+++ b/template/v4/v4.5/dirs/usr/local/bin/start-jupyter-server
@@ -56,8 +56,9 @@ if [ -n "$SAGEMAKER_APP_TYPE_LOWERCASE" ] && [ "$SAGEMAKER_SPACE_TYPE_LOWERCASE"
   jupyter labextension enable @jupyter/collaboration-extension
   jupyter labextension enable @jupyter/docprovider-extension
   jupyter server extension enable jupyter_server_ydoc
-  # Disable chat icon in shared spaces
-  jupyter labextension disable jupyterlab-chat-extension
+  # Jupyter AI is not intended for SMAI shared spaces.
+  micromamba remove -y jupyter-ai jupyter-ai-router jupyter-ai-persona-manager \
+    jupyter-ai-acp-client jupyter-ai-chat-commands jupyter-ai-tools jupyterlab-chat
   # SAGEMAKER_APP_TYPE is set, indicating the server is running within a SageMaker
   # app. Configure the base url to be `/<app-type-in-lower-case>/default`.
   # SAGEMAKER_SPACE_TYPE_LOWERCASE flag is used to determine if the server should start


### PR DESCRIPTION
## Description
Re-enable Jupyter AI in the `start-jupyter-server` templates for v4.1–v4.5, reversing the JAI removal from #1306 now that Jupyter AI 3.2 decouples the chat from real-time collaboration (RTC).
  
  #1306 disabled JAI in v4.1–v4.4 by uninstalling jupyter-ai (and related packages) at container startup, because RTC was the source of notebook truncation / data loss. With JAI 3.2.0, the chat no longer depends on RTC
  (jupyter-collaboration) — it uses jupyter-live-content instead — so JAI can run safely with RTC disabled.

## Type of Change
- [x] Image update - Bug fix
- [ ] Image update - New feature
- [ ] Image update - Breaking change
- [ ] SMD image build tool update
- [ ] Documentation update

## Release Information
Does this change need to be included in patch version releases? By default, any pull requests will only be added to the next SMD image minor version release once they are merged in template folder. Only critical bug fix or security update should be applied to new patch versions of existed image minor versions.
- [x] Yes (Critical bug fix or security update)
- [ ] No (New feature or non-critical change)
- [ ] N/A (Not an image update)

If yes, please explain why:
[Explain the criticality of this change and why it should be included in patch releases]

## How Has This Been Tested?
[Describe the tests you ran]

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Test Screenshots (if applicable):

## Related Issues
[Link any related issues here]

## Additional Notes
[Any additional information that might be helpful for reviewers]
